### PR TITLE
Additions to the Buffer API

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 object BuildHelper {
 
-  lazy val zioCoreVersion = "1.0.0-RC9"
+  lazy val zioCoreVersion = "1.0.0-RC10-1"
 
   def testz           = "0.0.5"
   def silencerVersion = "1.4.1"
@@ -21,7 +21,7 @@ object BuildHelper {
 
   val compileAndTest = Seq(
     "dev.zio" %% "zio-streams"      % zioCoreVersion,
-    "dev.zio" %% "zio-interop-java" % "1.1.0-RC1"
+    "dev.zio" %% "zio-interop-java" % "1.1.0.0-RC2"
   )
 
   private val stdOptions = Seq(

--- a/src/main/scala/zio/nio/Buffer.scala
+++ b/src/main/scala/zio/nio/Buffer.scala
@@ -1,8 +1,20 @@
 package zio.nio
 
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, Buffer => JBuffer, ByteBuffer => JByteBuffer, CharBuffer => JCharBuffer, DoubleBuffer => JDoubleBuffer, FloatBuffer => JFloatBuffer, IntBuffer => JIntBuffer, LongBuffer => JLongBuffer, ShortBuffer => JShortBuffer}
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  Buffer => JBuffer,
+  ByteBuffer => JByteBuffer,
+  CharBuffer => JCharBuffer,
+  DoubleBuffer => JDoubleBuffer,
+  FloatBuffer => JFloatBuffer,
+  IntBuffer => JIntBuffer,
+  LongBuffer => JLongBuffer,
+  ShortBuffer => JShortBuffer
+}
 
-import zio.{Chunk, IO, UIO, ZIO}
+import zio.{ Chunk, IO, UIO, ZIO }
 
 import scala.reflect.ClassTag
 
@@ -50,10 +62,14 @@ abstract class Buffer[A: ClassTag] private[nio] (private[nio] val buffer: JBuffe
 
   def duplicate: IO[Nothing, Buffer[A]]
 
-  final def withArray[R, E, B](noArray: ZIO[R, E, B])(hasArray: (Array[A], Int) => ZIO[R, E, B]): ZIO[R, E, B] = {
+  final def withArray[R, E, B](
+    noArray: ZIO[R, E, B]
+  )(
+    hasArray: (Array[A], Int) => ZIO[R, E, B]
+  ): ZIO[R, E, B] =
     if (buffer.hasArray) {
       for {
-        a <- array.orDie
+        a      <- array.orDie
         offset <- IO.effect(buffer.arrayOffset()).orDie
         result <- hasArray(a, offset)
       } yield {
@@ -62,7 +78,6 @@ abstract class Buffer[A: ClassTag] private[nio] (private[nio] val buffer: JBuffe
     } else {
       noArray
     }
-  }
 
   protected[nio] def array: IO[Exception, Array[A]]
 
@@ -85,52 +100,72 @@ abstract class Buffer[A: ClassTag] private[nio] (private[nio] val buffer: JBuffe
 object Buffer {
 
   def byte(capacity: Int): IO[IllegalArgumentException, ByteBuffer] =
-    IO.effect(JByteBuffer.allocate(capacity)).map(new ByteBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JByteBuffer.allocate(capacity))
+      .map(new ByteBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def byte(chunk: Chunk[Byte]): IO[Nothing, Buffer[Byte]] =
     IO.effectTotal(JByteBuffer.wrap(chunk.toArray)).map(new ByteBuffer(_))
 
   def byteDirect(capacity: Int): IO[IllegalArgumentException, ByteBuffer] =
-    IO.effect(new ByteBuffer(JByteBuffer.allocateDirect(capacity))).refineToOrDie[IllegalArgumentException]
+    IO.effect(new ByteBuffer(JByteBuffer.allocateDirect(capacity)))
+      .refineToOrDie[IllegalArgumentException]
 
   def char(capacity: Int): IO[IllegalArgumentException, CharBuffer] =
-    IO.effect(JCharBuffer.allocate(capacity)).map(new CharBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JCharBuffer.allocate(capacity))
+      .map(new CharBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def char(chunk: Chunk[Char]): IO[Nothing, CharBuffer] =
     IO.effectTotal(JCharBuffer.wrap(chunk.toArray)).map(new CharBuffer(_))
 
-  def char(charSequence: CharSequence, start: Int, end: Int): IO[IndexOutOfBoundsException, CharBuffer] =
-    IO.effect(new CharBuffer(JCharBuffer.wrap(charSequence, start, end))).refineToOrDie[IndexOutOfBoundsException]
+  def char(
+    charSequence: CharSequence,
+    start: Int,
+    end: Int
+  ): IO[IndexOutOfBoundsException, CharBuffer] =
+    IO.effect(new CharBuffer(JCharBuffer.wrap(charSequence, start, end)))
+      .refineToOrDie[IndexOutOfBoundsException]
 
   def char(charSequence: CharSequence): IO[Nothing, CharBuffer] =
     IO.effectTotal(new CharBuffer(JCharBuffer.wrap(charSequence)))
 
   def float(capacity: Int): IO[IllegalArgumentException, FloatBuffer] =
-    IO.effect(JFloatBuffer.allocate(capacity)).map(new FloatBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JFloatBuffer.allocate(capacity))
+      .map(new FloatBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def float(chunk: Chunk[Float]): IO[Nothing, FloatBuffer] =
     IO.effectTotal(JFloatBuffer.wrap(chunk.toArray)).map(new FloatBuffer(_))
 
   def double(capacity: Int): IO[IllegalArgumentException, DoubleBuffer] =
-    IO.effect(JDoubleBuffer.allocate(capacity)).map(new DoubleBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JDoubleBuffer.allocate(capacity))
+      .map(new DoubleBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def double(chunk: Chunk[Double]): IO[Nothing, DoubleBuffer] =
     IO.effectTotal(JDoubleBuffer.wrap(chunk.toArray)).map(new DoubleBuffer(_))
 
   def int(capacity: Int): IO[IllegalArgumentException, IntBuffer] =
-    IO.effect(JIntBuffer.allocate(capacity)).map(new IntBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JIntBuffer.allocate(capacity))
+      .map(new IntBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def int(chunk: Chunk[Int]): IO[Nothing, IntBuffer] =
     IO.effectTotal(JIntBuffer.wrap(chunk.toArray)).map(new IntBuffer(_))
 
   def long(capacity: Int): IO[IllegalArgumentException, LongBuffer] =
-    IO.effect(JLongBuffer.allocate(capacity)).map(new LongBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JLongBuffer.allocate(capacity))
+      .map(new LongBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def long(chunk: Chunk[Long]): IO[Nothing, LongBuffer] =
     IO.effectTotal(JLongBuffer.wrap(chunk.toArray)).map(new LongBuffer(_))
 
   def short(capacity: Int): IO[IllegalArgumentException, ShortBuffer] =
-    IO.effect(JShortBuffer.allocate(capacity)).map(new ShortBuffer(_)).refineToOrDie[IllegalArgumentException]
+    IO.effect(JShortBuffer.allocate(capacity))
+      .map(new ShortBuffer(_))
+      .refineToOrDie[IllegalArgumentException]
 
   def short(chunk: Chunk[Short]): IO[Nothing, ShortBuffer] =
     IO.effectTotal(JShortBuffer.wrap(chunk.toArray)).map(new ShortBuffer(_))

--- a/src/main/scala/zio/nio/ByteBuffer.scala
+++ b/src/main/scala/zio/nio/ByteBuffer.scala
@@ -1,7 +1,12 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, ByteBuffer => JByteBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  ByteBuffer => JByteBuffer
+}
 
 final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer) {
 
@@ -16,7 +21,8 @@ final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer)
   override def compact: IO[ReadOnlyBufferException, Unit] =
     IO.effect(byteBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, ByteBuffer] = IO.effectTotal(new ByteBuffer(byteBuffer.duplicate()))
+  override def duplicate: IO[Nothing, ByteBuffer] =
+    IO.effectTotal(new ByteBuffer(byteBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JByteBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(byteBuffer)
 
@@ -26,11 +32,13 @@ final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer)
   override def get(i: Int): IO[IndexOutOfBoundsException, Byte] =
     IO.effect(byteBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Byte]] = IO.effect {
-    val array = Array.ofDim[Byte](math.min(maxLength, byteBuffer.remaining()))
-    byteBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Byte]] =
+    IO.effect {
+        val array = Array.ofDim[Byte](math.min(maxLength, byteBuffer.remaining()))
+        byteBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   override def put(element: Byte): IO[Exception, Unit] =
     IO.effect(byteBuffer.put(element)).unit.refineToOrDie[Exception]
@@ -38,10 +46,13 @@ final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer)
   override def put(index: Int, element: Byte): IO[Exception, Unit] =
     IO.effect(byteBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Byte]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    byteBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Byte]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        byteBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, ByteBuffer] =
     IO.effectTotal(byteBuffer.asReadOnlyBuffer()).map(new ByteBuffer(_))

--- a/src/main/scala/zio/nio/CharBuffer.scala
+++ b/src/main/scala/zio/nio/CharBuffer.scala
@@ -1,30 +1,49 @@
 package zio.nio
 
-import zio.IO
+import zio.{Chunk, IO, ZIO}
+import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, CharBuffer => JCharBuffer}
 
-import java.nio.{ ByteOrder, CharBuffer => JCharBuffer }
+final class CharBuffer(charBuffer: JCharBuffer) extends Buffer[Char](charBuffer) {
 
-private[nio] class CharBuffer(val charBuffer: JCharBuffer) extends Buffer[Char](charBuffer) {
-
-  override val array: IO[Exception, Array[Char]] =
+  override protected[nio] def array: IO[Exception, Array[Char]] =
     IO.effect(charBuffer.array()).refineToOrDie[Exception]
 
-  val order: IO[Nothing, ByteOrder] = IO.succeed(charBuffer.order())
+  override def order: ByteOrder = charBuffer.order()
 
-  val slice: IO[Exception, CharBuffer] =
-    IO.effect(charBuffer.slice()).map(new CharBuffer(_)).refineToOrDie[Exception]
+  override def slice: IO[Nothing, CharBuffer] =
+    IO.effectTotal(charBuffer.slice()).map(new CharBuffer(_))
 
-  override val get: IO[Exception, Char] = IO.effect(charBuffer.get()).refineToOrDie[Exception]
+  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(charBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def get(i: Int): IO[Exception, Char] =
-    IO.effect(charBuffer.get(i)).refineToOrDie[Exception]
+  override def duplicate: IO[Nothing, CharBuffer] = IO.effectTotal(new CharBuffer(charBuffer.duplicate()))
 
-  override def put(element: Char): IO[Exception, CharBuffer] =
-    IO.effect(charBuffer.put(element)).map(new CharBuffer(_)).refineToOrDie[Exception]
+  def withJavaBuffer[R, E, A](f: JCharBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(charBuffer)
 
-  override def put(index: Int, element: Char): IO[Exception, CharBuffer] =
-    IO.effect(charBuffer.put(index, element)).map(new CharBuffer(_)).refineToOrDie[Exception]
+  override def get: IO[BufferUnderflowException, Char] = IO.effect(charBuffer.get()).refineToOrDie[BufferUnderflowException]
 
-  override val asReadOnlyBuffer: IO[Exception, CharBuffer] =
-    IO.effect(charBuffer.asReadOnlyBuffer()).map(new CharBuffer(_)).refineToOrDie[Exception]
+  override def get(i: Int): IO[IndexOutOfBoundsException, Char] =
+    IO.effect(charBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
+
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Char]] = IO.effect {
+    val array = Array.ofDim[Char](math.min(maxLength, charBuffer.remaining()))
+    charBuffer.get(array)
+    Chunk.fromArray(array)
+  }.refineToOrDie[BufferUnderflowException]
+
+  def getString: IO[Nothing, String] = IO.effectTotal(charBuffer.toString())
+
+  override def put(element: Char): IO[Exception, Unit] =
+    IO.effect(charBuffer.put(element)).unit.refineToOrDie[Exception]
+
+  override def put(index: Int, element: Char): IO[Exception, Unit] =
+    IO.effect(charBuffer.put(index, element)).unit.refineToOrDie[Exception]
+
+  override def putChunk(chunk: Chunk[Char]): IO[Exception, Unit] = IO.effect {
+    val array = chunk.toArray
+    charBuffer.put(array)
+  }.unit.refineToOrDie[Exception]
+
+  override def asReadOnlyBuffer: IO[Nothing, CharBuffer] =
+    IO.effectTotal(charBuffer.asReadOnlyBuffer()).map(new CharBuffer(_))
+
 }

--- a/src/main/scala/zio/nio/CharBuffer.scala
+++ b/src/main/scala/zio/nio/CharBuffer.scala
@@ -1,7 +1,12 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, CharBuffer => JCharBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  CharBuffer => JCharBuffer
+}
 
 final class CharBuffer(charBuffer: JCharBuffer) extends Buffer[Char](charBuffer) {
 
@@ -13,22 +18,27 @@ final class CharBuffer(charBuffer: JCharBuffer) extends Buffer[Char](charBuffer)
   override def slice: IO[Nothing, CharBuffer] =
     IO.effectTotal(charBuffer.slice()).map(new CharBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(charBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
+  override def compact: IO[ReadOnlyBufferException, Unit] =
+    IO.effect(charBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, CharBuffer] = IO.effectTotal(new CharBuffer(charBuffer.duplicate()))
+  override def duplicate: IO[Nothing, CharBuffer] =
+    IO.effectTotal(new CharBuffer(charBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JCharBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(charBuffer)
 
-  override def get: IO[BufferUnderflowException, Char] = IO.effect(charBuffer.get()).refineToOrDie[BufferUnderflowException]
+  override def get: IO[BufferUnderflowException, Char] =
+    IO.effect(charBuffer.get()).refineToOrDie[BufferUnderflowException]
 
   override def get(i: Int): IO[IndexOutOfBoundsException, Char] =
     IO.effect(charBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Char]] = IO.effect {
-    val array = Array.ofDim[Char](math.min(maxLength, charBuffer.remaining()))
-    charBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Char]] =
+    IO.effect {
+        val array = Array.ofDim[Char](math.min(maxLength, charBuffer.remaining()))
+        charBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   def getString: IO[Nothing, String] = IO.effectTotal(charBuffer.toString())
 
@@ -38,10 +48,13 @@ final class CharBuffer(charBuffer: JCharBuffer) extends Buffer[Char](charBuffer)
   override def put(index: Int, element: Char): IO[Exception, Unit] =
     IO.effect(charBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Char]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    charBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Char]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        charBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, CharBuffer] =
     IO.effectTotal(charBuffer.asReadOnlyBuffer()).map(new CharBuffer(_))

--- a/src/main/scala/zio/nio/DoubleBuffer.scala
+++ b/src/main/scala/zio/nio/DoubleBuffer.scala
@@ -1,32 +1,49 @@
 package zio.nio
 
-import zio.IO
+import zio.{Chunk, IO, ZIO}
+import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, DoubleBuffer => JDoubleBuffer}
 
-import java.nio.{ ByteOrder, DoubleBuffer => JDoubleBuffer }
-
-private[nio] class DoubleBuffer(val doubleBuffer: JDoubleBuffer)
+final class DoubleBuffer(doubleBuffer: JDoubleBuffer)
     extends Buffer[Double](doubleBuffer) {
 
-  override val array: IO[Exception, Array[Double]] =
+  override protected[nio] def array: IO[Exception, Array[Double]] =
     IO.effect(doubleBuffer.array()).refineToOrDie[Exception]
 
-  val order: IO[Nothing, ByteOrder] = IO.succeed(doubleBuffer.order())
+  override def order: ByteOrder = doubleBuffer.order
 
-  val slice: IO[Exception, DoubleBuffer] =
-    IO.effect(doubleBuffer.slice()).map(new DoubleBuffer(_)).refineToOrDie[Exception]
+  override def slice: IO[Nothing, DoubleBuffer] =
+    IO.effectTotal(doubleBuffer.slice()).map(new DoubleBuffer(_))
 
-  override val get: IO[Exception, Double] =
-    IO.effect(doubleBuffer.get()).refineToOrDie[Exception]
+  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(doubleBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def get(i: Int): IO[Exception, Double] =
-    IO.effect(doubleBuffer.get(i)).refineToOrDie[Exception]
+  override def duplicate: IO[Nothing, DoubleBuffer] = IO.effectTotal(new DoubleBuffer(doubleBuffer.duplicate()))
 
-  override def put(element: Double): IO[Exception, DoubleBuffer] =
-    IO.effect(doubleBuffer.put(element)).map(new DoubleBuffer(_)).refineToOrDie[Exception]
+  def withJavaBuffer[R, E, A](f: JDoubleBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(doubleBuffer)
 
-  override def put(index: Int, element: Double): IO[Exception, DoubleBuffer] =
-    IO.effect(doubleBuffer.put(index, element)).map(new DoubleBuffer(_)).refineToOrDie[Exception]
+  override def get: IO[BufferUnderflowException, Double] =
+    IO.effect(doubleBuffer.get()).refineToOrDie[BufferUnderflowException]
 
-  override val asReadOnlyBuffer: IO[Exception, DoubleBuffer] =
-    IO.effect(doubleBuffer.asReadOnlyBuffer()).map(new DoubleBuffer(_)).refineToOrDie[Exception]
+  override def get(i: Int): IO[IndexOutOfBoundsException, Double] =
+    IO.effect(doubleBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
+
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Double]] = IO.effect {
+    val array = Array.ofDim[Double](math.min(maxLength, doubleBuffer.remaining()))
+    doubleBuffer.get(array)
+    Chunk.fromArray(array)
+  }.refineToOrDie[BufferUnderflowException]
+
+  override def put(element: Double): IO[Exception, Unit] =
+    IO.effect(doubleBuffer.put(element)).unit.refineToOrDie[Exception]
+
+  override def put(index: Int, element: Double): IO[Exception, Unit] =
+    IO.effect(doubleBuffer.put(index, element)).unit.refineToOrDie[Exception]
+
+  override def putChunk(chunk: Chunk[Double]): IO[Exception, Unit] = IO.effect {
+    val array = chunk.toArray
+    doubleBuffer.put(array)
+  }.unit.refineToOrDie[Exception]
+
+  override def asReadOnlyBuffer: IO[Nothing, DoubleBuffer] =
+    IO.effectTotal(doubleBuffer.asReadOnlyBuffer()).map(new DoubleBuffer(_))
+
 }

--- a/src/main/scala/zio/nio/DoubleBuffer.scala
+++ b/src/main/scala/zio/nio/DoubleBuffer.scala
@@ -1,10 +1,14 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, DoubleBuffer => JDoubleBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  DoubleBuffer => JDoubleBuffer
+}
 
-final class DoubleBuffer(doubleBuffer: JDoubleBuffer)
-    extends Buffer[Double](doubleBuffer) {
+final class DoubleBuffer(doubleBuffer: JDoubleBuffer) extends Buffer[Double](doubleBuffer) {
 
   override protected[nio] def array: IO[Exception, Array[Double]] =
     IO.effect(doubleBuffer.array()).refineToOrDie[Exception]
@@ -14,9 +18,11 @@ final class DoubleBuffer(doubleBuffer: JDoubleBuffer)
   override def slice: IO[Nothing, DoubleBuffer] =
     IO.effectTotal(doubleBuffer.slice()).map(new DoubleBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(doubleBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
+  override def compact: IO[ReadOnlyBufferException, Unit] =
+    IO.effect(doubleBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, DoubleBuffer] = IO.effectTotal(new DoubleBuffer(doubleBuffer.duplicate()))
+  override def duplicate: IO[Nothing, DoubleBuffer] =
+    IO.effectTotal(new DoubleBuffer(doubleBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JDoubleBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(doubleBuffer)
 
@@ -26,11 +32,15 @@ final class DoubleBuffer(doubleBuffer: JDoubleBuffer)
   override def get(i: Int): IO[IndexOutOfBoundsException, Double] =
     IO.effect(doubleBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Double]] = IO.effect {
-    val array = Array.ofDim[Double](math.min(maxLength, doubleBuffer.remaining()))
-    doubleBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(
+    maxLength: Int = Int.MaxValue
+  ): IO[BufferUnderflowException, Chunk[Double]] =
+    IO.effect {
+        val array = Array.ofDim[Double](math.min(maxLength, doubleBuffer.remaining()))
+        doubleBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   override def put(element: Double): IO[Exception, Unit] =
     IO.effect(doubleBuffer.put(element)).unit.refineToOrDie[Exception]
@@ -38,10 +48,13 @@ final class DoubleBuffer(doubleBuffer: JDoubleBuffer)
   override def put(index: Int, element: Double): IO[Exception, Unit] =
     IO.effect(doubleBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Double]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    doubleBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Double]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        doubleBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, DoubleBuffer] =
     IO.effectTotal(doubleBuffer.asReadOnlyBuffer()).map(new DoubleBuffer(_))

--- a/src/main/scala/zio/nio/FloatBuffer.scala
+++ b/src/main/scala/zio/nio/FloatBuffer.scala
@@ -1,7 +1,12 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, FloatBuffer => JFloatBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  FloatBuffer => JFloatBuffer
+}
 
 final class FloatBuffer(floatBuffer: JFloatBuffer) extends Buffer[Float](floatBuffer) {
 
@@ -13,22 +18,27 @@ final class FloatBuffer(floatBuffer: JFloatBuffer) extends Buffer[Float](floatBu
   override def slice: IO[Nothing, FloatBuffer] =
     IO.effectTotal(floatBuffer.slice()).map(new FloatBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(floatBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
+  override def compact: IO[ReadOnlyBufferException, Unit] =
+    IO.effect(floatBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, FloatBuffer] = IO.effectTotal(new FloatBuffer(floatBuffer.duplicate()))
+  override def duplicate: IO[Nothing, FloatBuffer] =
+    IO.effectTotal(new FloatBuffer(floatBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JFloatBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(floatBuffer)
 
-  override def get: IO[BufferUnderflowException, Float] = IO.effect(floatBuffer.get()).refineToOrDie[BufferUnderflowException]
+  override def get: IO[BufferUnderflowException, Float] =
+    IO.effect(floatBuffer.get()).refineToOrDie[BufferUnderflowException]
 
   override def get(i: Int): IO[IndexOutOfBoundsException, Float] =
     IO.effect(floatBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Float]] = IO.effect {
-    val array = Array.ofDim[Float](math.min(maxLength, floatBuffer.remaining()))
-    floatBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Float]] =
+    IO.effect {
+        val array = Array.ofDim[Float](math.min(maxLength, floatBuffer.remaining()))
+        floatBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   override def put(element: Float): IO[Exception, Unit] =
     IO.effect(floatBuffer.put(element)).unit.refineToOrDie[Exception]
@@ -36,10 +46,13 @@ final class FloatBuffer(floatBuffer: JFloatBuffer) extends Buffer[Float](floatBu
   override def put(index: Int, element: Float): IO[Exception, Unit] =
     IO.effect(floatBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Float]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    floatBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Float]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        floatBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, FloatBuffer] =
     IO.effectTotal(floatBuffer.asReadOnlyBuffer()).map(new FloatBuffer(_))

--- a/src/main/scala/zio/nio/FloatBuffer.scala
+++ b/src/main/scala/zio/nio/FloatBuffer.scala
@@ -1,30 +1,47 @@
 package zio.nio
 
-import zio.IO
+import zio.{Chunk, IO, ZIO}
+import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, FloatBuffer => JFloatBuffer}
 
-import java.nio.{ ByteOrder, FloatBuffer => JFloatBuffer }
+final class FloatBuffer(floatBuffer: JFloatBuffer) extends Buffer[Float](floatBuffer) {
 
-private[nio] class FloatBuffer(val floatBuffer: JFloatBuffer) extends Buffer[Float](floatBuffer) {
-
-  override val array: IO[Exception, Array[Float]] =
+  override protected[nio] def array: IO[Exception, Array[Float]] =
     IO.effect(floatBuffer.array()).refineToOrDie[Exception]
 
-  def order: IO[Nothing, ByteOrder] = IO.succeed(floatBuffer.order())
+  override def order: ByteOrder = floatBuffer.order
 
-  def slice: IO[Exception, FloatBuffer] =
-    IO.effect(floatBuffer.slice()).map(new FloatBuffer(_)).refineToOrDie[Exception]
+  override def slice: IO[Nothing, FloatBuffer] =
+    IO.effectTotal(floatBuffer.slice()).map(new FloatBuffer(_))
 
-  override val get: IO[Exception, Float] = IO.effect(floatBuffer.get()).refineToOrDie[Exception]
+  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(floatBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def get(i: Int): IO[Exception, Float] =
-    IO.effect(floatBuffer.get(i)).refineToOrDie[Exception]
+  override def duplicate: IO[Nothing, FloatBuffer] = IO.effectTotal(new FloatBuffer(floatBuffer.duplicate()))
 
-  override def put(element: Float): IO[Exception, FloatBuffer] =
-    IO.effect(floatBuffer.put(element)).map(new FloatBuffer(_)).refineToOrDie[Exception]
+  def withJavaBuffer[R, E, A](f: JFloatBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(floatBuffer)
 
-  override def put(index: Int, element: Float): IO[Exception, FloatBuffer] =
-    IO.effect(floatBuffer.put(index, element)).map(new FloatBuffer(_)).refineToOrDie[Exception]
+  override def get: IO[BufferUnderflowException, Float] = IO.effect(floatBuffer.get()).refineToOrDie[BufferUnderflowException]
 
-  override val asReadOnlyBuffer: IO[Exception, FloatBuffer] =
-    IO.effect(floatBuffer.asReadOnlyBuffer()).map(new FloatBuffer(_)).refineToOrDie[Exception]
+  override def get(i: Int): IO[IndexOutOfBoundsException, Float] =
+    IO.effect(floatBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
+
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Float]] = IO.effect {
+    val array = Array.ofDim[Float](math.min(maxLength, floatBuffer.remaining()))
+    floatBuffer.get(array)
+    Chunk.fromArray(array)
+  }.refineToOrDie[BufferUnderflowException]
+
+  override def put(element: Float): IO[Exception, Unit] =
+    IO.effect(floatBuffer.put(element)).unit.refineToOrDie[Exception]
+
+  override def put(index: Int, element: Float): IO[Exception, Unit] =
+    IO.effect(floatBuffer.put(index, element)).unit.refineToOrDie[Exception]
+
+  override def putChunk(chunk: Chunk[Float]): IO[Exception, Unit] = IO.effect {
+    val array = chunk.toArray
+    floatBuffer.put(array)
+  }.unit.refineToOrDie[Exception]
+
+  override def asReadOnlyBuffer: IO[Nothing, FloatBuffer] =
+    IO.effectTotal(floatBuffer.asReadOnlyBuffer()).map(new FloatBuffer(_))
+
 }

--- a/src/main/scala/zio/nio/IntBuffer.scala
+++ b/src/main/scala/zio/nio/IntBuffer.scala
@@ -1,7 +1,12 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, IntBuffer => JIntBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  IntBuffer => JIntBuffer
+}
 
 final class IntBuffer(val intBuffer: JIntBuffer) extends Buffer[Int](intBuffer) {
 
@@ -13,22 +18,27 @@ final class IntBuffer(val intBuffer: JIntBuffer) extends Buffer[Int](intBuffer) 
   override def slice: IO[Nothing, IntBuffer] =
     IO.effectTotal(intBuffer.slice()).map(new IntBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(intBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
+  override def compact: IO[ReadOnlyBufferException, Unit] =
+    IO.effect(intBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, IntBuffer] = IO.effectTotal(new IntBuffer(intBuffer.duplicate()))
+  override def duplicate: IO[Nothing, IntBuffer] =
+    IO.effectTotal(new IntBuffer(intBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JIntBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(intBuffer)
 
-  override def get: IO[BufferUnderflowException, Int] = IO.effect(intBuffer.get()).refineToOrDie[BufferUnderflowException]
+  override def get: IO[BufferUnderflowException, Int] =
+    IO.effect(intBuffer.get()).refineToOrDie[BufferUnderflowException]
 
   override def get(i: Int): IO[IndexOutOfBoundsException, Int] =
     IO.effect(intBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Int]] = IO.effect {
-    val array = Array.ofDim[Int](math.min(maxLength, intBuffer.remaining()))
-    intBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Int]] =
+    IO.effect {
+        val array = Array.ofDim[Int](math.min(maxLength, intBuffer.remaining()))
+        intBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   override def put(element: Int): IO[Exception, Unit] =
     IO.effect(intBuffer.put(element)).unit.refineToOrDie[Exception]
@@ -36,10 +46,13 @@ final class IntBuffer(val intBuffer: JIntBuffer) extends Buffer[Int](intBuffer) 
   override def put(index: Int, element: Int): IO[Exception, Unit] =
     IO.effect(intBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Int]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    intBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Int]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        intBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, IntBuffer] =
     IO.effectTotal(intBuffer.asReadOnlyBuffer()).map(new IntBuffer(_))

--- a/src/main/scala/zio/nio/IntBuffer.scala
+++ b/src/main/scala/zio/nio/IntBuffer.scala
@@ -1,30 +1,47 @@
 package zio.nio
 
-import zio.IO
+import zio.{Chunk, IO, ZIO}
+import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, IntBuffer => JIntBuffer}
 
-import java.nio.{ ByteOrder, IntBuffer => JIntBuffer }
+final class IntBuffer(val intBuffer: JIntBuffer) extends Buffer[Int](intBuffer) {
 
-private[nio] class IntBuffer(val intBuffer: JIntBuffer) extends Buffer[Int](intBuffer) {
-
-  override val array: IO[Exception, Array[Int]] =
+  override protected[nio] def array: IO[Exception, Array[Int]] =
     IO.effect(intBuffer.array()).refineToOrDie[Exception]
 
-  def order: IO[Nothing, ByteOrder] = IO.succeed(intBuffer.order())
+  override def order: ByteOrder = intBuffer.order
 
-  def slice: IO[Exception, IntBuffer] =
-    IO.effect(intBuffer.slice()).map(new IntBuffer(_)).refineToOrDie[Exception]
+  override def slice: IO[Nothing, IntBuffer] =
+    IO.effectTotal(intBuffer.slice()).map(new IntBuffer(_))
 
-  override val get: IO[Exception, Int] = IO.effect(intBuffer.get()).refineToOrDie[Exception]
+  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(intBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def get(i: Int): IO[Exception, Int] =
-    IO.effect(intBuffer.get(i)).refineToOrDie[Exception]
+  override def duplicate: IO[Nothing, IntBuffer] = IO.effectTotal(new IntBuffer(intBuffer.duplicate()))
 
-  override def put(element: Int): IO[Exception, IntBuffer] =
-    IO.effect(intBuffer.put(element)).map(new IntBuffer(_)).refineToOrDie[Exception]
+  def withJavaBuffer[R, E, A](f: JIntBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(intBuffer)
 
-  override def put(index: Int, element: Int): IO[Exception, IntBuffer] =
-    IO.effect(intBuffer.put(index, element)).map(new IntBuffer(_)).refineToOrDie[Exception]
+  override def get: IO[BufferUnderflowException, Int] = IO.effect(intBuffer.get()).refineToOrDie[BufferUnderflowException]
 
-  override val asReadOnlyBuffer: IO[Exception, IntBuffer] =
-    IO.effect(intBuffer.asReadOnlyBuffer()).map(new IntBuffer(_)).refineToOrDie[Exception]
+  override def get(i: Int): IO[IndexOutOfBoundsException, Int] =
+    IO.effect(intBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
+
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Int]] = IO.effect {
+    val array = Array.ofDim[Int](math.min(maxLength, intBuffer.remaining()))
+    intBuffer.get(array)
+    Chunk.fromArray(array)
+  }.refineToOrDie[BufferUnderflowException]
+
+  override def put(element: Int): IO[Exception, Unit] =
+    IO.effect(intBuffer.put(element)).unit.refineToOrDie[Exception]
+
+  override def put(index: Int, element: Int): IO[Exception, Unit] =
+    IO.effect(intBuffer.put(index, element)).unit.refineToOrDie[Exception]
+
+  override def putChunk(chunk: Chunk[Int]): IO[Exception, Unit] = IO.effect {
+    val array = chunk.toArray
+    intBuffer.put(array)
+  }.unit.refineToOrDie[Exception]
+
+  override def asReadOnlyBuffer: IO[Nothing, IntBuffer] =
+    IO.effectTotal(intBuffer.asReadOnlyBuffer()).map(new IntBuffer(_))
+
 }

--- a/src/main/scala/zio/nio/LongBuffer.scala
+++ b/src/main/scala/zio/nio/LongBuffer.scala
@@ -1,7 +1,12 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, LongBuffer => JLongBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  LongBuffer => JLongBuffer
+}
 
 final class LongBuffer(val longBuffer: JLongBuffer) extends Buffer[Long](longBuffer) {
 
@@ -13,22 +18,27 @@ final class LongBuffer(val longBuffer: JLongBuffer) extends Buffer[Long](longBuf
   override def slice: IO[Nothing, LongBuffer] =
     IO.effectTotal(longBuffer.slice()).map(new LongBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(longBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
+  override def compact: IO[ReadOnlyBufferException, Unit] =
+    IO.effect(longBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, LongBuffer] = IO.effectTotal(new LongBuffer(longBuffer.duplicate()))
+  override def duplicate: IO[Nothing, LongBuffer] =
+    IO.effectTotal(new LongBuffer(longBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JLongBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(longBuffer)
 
-  override def get: IO[BufferUnderflowException, Long] = IO.effect(longBuffer.get()).refineToOrDie[BufferUnderflowException]
+  override def get: IO[BufferUnderflowException, Long] =
+    IO.effect(longBuffer.get()).refineToOrDie[BufferUnderflowException]
 
   override def get(i: Int): IO[IndexOutOfBoundsException, Long] =
     IO.effect(longBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Long]] = IO.effect {
-    val array = Array.ofDim[Long](math.min(maxLength, longBuffer.remaining()))
-    longBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Long]] =
+    IO.effect {
+        val array = Array.ofDim[Long](math.min(maxLength, longBuffer.remaining()))
+        longBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   override def put(element: Long): IO[Exception, Unit] =
     IO.effect(longBuffer.put(element)).unit.refineToOrDie[Exception]
@@ -36,10 +46,13 @@ final class LongBuffer(val longBuffer: JLongBuffer) extends Buffer[Long](longBuf
   override def put(index: Int, element: Long): IO[Exception, Unit] =
     IO.effect(longBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Long]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    longBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Long]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        longBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, LongBuffer] =
     IO.effectTotal(longBuffer.asReadOnlyBuffer()).map(new LongBuffer(_))

--- a/src/main/scala/zio/nio/ShortBuffer.scala
+++ b/src/main/scala/zio/nio/ShortBuffer.scala
@@ -1,7 +1,12 @@
 package zio.nio
 
-import zio.{Chunk, IO, ZIO}
-import java.nio.{BufferUnderflowException, ByteOrder, ReadOnlyBufferException, ShortBuffer => JShortBuffer}
+import zio.{ Chunk, IO, ZIO }
+import java.nio.{
+  BufferUnderflowException,
+  ByteOrder,
+  ReadOnlyBufferException,
+  ShortBuffer => JShortBuffer
+}
 
 final class ShortBuffer(val shortBuffer: JShortBuffer) extends Buffer[Short](shortBuffer) {
 
@@ -13,22 +18,27 @@ final class ShortBuffer(val shortBuffer: JShortBuffer) extends Buffer[Short](sho
   override def slice: IO[Nothing, ShortBuffer] =
     IO.effectTotal(shortBuffer.slice()).map(new ShortBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] = IO.effect(shortBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
+  override def compact: IO[ReadOnlyBufferException, Unit] =
+    IO.effect(shortBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, ShortBuffer] = IO.effectTotal(new ShortBuffer(shortBuffer.duplicate()))
+  override def duplicate: IO[Nothing, ShortBuffer] =
+    IO.effectTotal(new ShortBuffer(shortBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JShortBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(shortBuffer)
 
-  override def get: IO[BufferUnderflowException, Short] = IO.effect(shortBuffer.get()).refineToOrDie[BufferUnderflowException]
+  override def get: IO[BufferUnderflowException, Short] =
+    IO.effect(shortBuffer.get()).refineToOrDie[BufferUnderflowException]
 
   override def get(i: Int): IO[IndexOutOfBoundsException, Short] =
     IO.effect(shortBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int): IO[BufferUnderflowException, Chunk[Short]] = IO.effect {
-    val array = Array.ofDim[Short](math.min(maxLength, shortBuffer.remaining()))
-    shortBuffer.get(array)
-    Chunk.fromArray(array)
-  }.refineToOrDie[BufferUnderflowException]
+  override def getChunk(maxLength: Int): IO[BufferUnderflowException, Chunk[Short]] =
+    IO.effect {
+        val array = Array.ofDim[Short](math.min(maxLength, shortBuffer.remaining()))
+        shortBuffer.get(array)
+        Chunk.fromArray(array)
+      }
+      .refineToOrDie[BufferUnderflowException]
 
   override def put(element: Short): IO[Exception, Unit] =
     IO.effect(shortBuffer.put(element)).unit.refineToOrDie[Exception]
@@ -36,10 +46,13 @@ final class ShortBuffer(val shortBuffer: JShortBuffer) extends Buffer[Short](sho
   override def put(index: Int, element: Short): IO[Exception, Unit] =
     IO.effect(shortBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Short]): IO[Exception, Unit] = IO.effect {
-    val array = chunk.toArray
-    shortBuffer.put(array)
-  }.unit.refineToOrDie[Exception]
+  override def putChunk(chunk: Chunk[Short]): IO[Exception, Unit] =
+    IO.effect {
+        val array = chunk.toArray
+        shortBuffer.put(array)
+      }
+      .unit
+      .refineToOrDie[Exception]
 
   override def asReadOnlyBuffer: IO[Nothing, ShortBuffer] =
     IO.effectTotal(shortBuffer.asReadOnlyBuffer()).map(new ShortBuffer(_))

--- a/src/test/scala/zio/nio/BufferSuite.scala
+++ b/src/test/scala/zio/nio/BufferSuite.scala
@@ -291,7 +291,7 @@ object BufferSuite extends DefaultRuntime {
       test("heap buffers a backed by an array") { () =>
         val hasArray =
           for {
-            b        <- allocate(initialCapacity)
+            b <- allocate(initialCapacity)
           } yield b.hasArray
         assert(unsafeRun(hasArray))
       }, {

--- a/src/test/scala/zio/nio/BufferSuite.scala
+++ b/src/test/scala/zio/nio/BufferSuite.scala
@@ -164,12 +164,12 @@ object BufferSuite extends DefaultRuntime {
       //   }
       // ),
       test("capacity") { () =>
-        val capacity = unsafeRun(allocate(initialCapacity).flatMap(_.capacity))
+        val capacity = unsafeRun(allocate(initialCapacity).map(_.capacity))
         assert(capacity == jAllocate(initialCapacity).capacity)
       },
       namedSection("allocate")(
         test("capacity initialized") { () =>
-          val capacity = unsafeRun(allocate(initialCapacity).flatMap(_.capacity))
+          val capacity = unsafeRun(allocate(initialCapacity).map(_.capacity))
           assert(capacity == initialCapacity)
         },
         test("position is 0") { () =>
@@ -292,8 +292,7 @@ object BufferSuite extends DefaultRuntime {
         val hasArray =
           for {
             b        <- allocate(initialCapacity)
-            hasArray <- b.hasArray
-          } yield hasArray
+          } yield b.hasArray
         assert(unsafeRun(hasArray))
       }, {
         namedSection("invariant")(


### PR DESCRIPTION
## Access to the underlying array or Java buffer

The current API provides `hasArray`/`array` to get access to the buffer's underlying array, if it has one. This allows ZIO buffers to interoperate with APIs using arrays, which are very common. However, there's also a need to interoperate with APIs using Java buffers. Using the Java buffer directly is unsafe, but no more unsafe than using the array directly.

The proposed change here is to expose both the array and the Java buffer via the public API, but instead of just providing them to the user, the user must provide a function accepting the array/buffer and returning a ZIO effect:

```scala
def withArray[R, E, B](noArray: ZIO[R, E, B])(hasArray: (Array[A], Int) => ZIO[R, E, B]): ZIO[R, E, B]
```

Of course, we cannot ensure safe use of the array, but this at least gives a strong hint that the array should only be used inside an effect block. It also requires dealing with the possibility that the buffer is not array backed in a neater way than checking `hasArray`.

Access to the Java buffer, along with useful extra methods on `ByteBuffer` and `CharBuffer` means that it makes a lot of sense to just make all the `Buffer` subclasses public.

## Other changes:

* Some of the Java APIs are referentially transparent (eg `capacity` and `order`), so they don't need to return in ZIO.
* Limit error types to just those the Java API is documented to throw.
* Returning `this` from write methods seems more confusing than useful when using an effect type, so return `Unit` instead.
* Use `def` for all members. Sure, `val` is a little faster, but it adds memory overhead to every single buffer created, including "views".
* Add convenience methods to read/write `Chunk`s.
* Add `duplicate`
* Add `compact`
