### PR TITLE
Improvements to the Async File Channel API.

### DIFF
--- a/src/main/scala/zio/nio/Buffer.scala
+++ b/src/main/scala/zio/nio/Buffer.scala
@@ -104,7 +104,7 @@ object Buffer {
       .map(new ByteBuffer(_))
       .refineToOrDie[IllegalArgumentException]
 
-  def byte(chunk: Chunk[Byte]): IO[Nothing, Buffer[Byte]] =
+  def byte(chunk: Chunk[Byte]): IO[Nothing, ByteBuffer] =
     IO.effectTotal(JByteBuffer.wrap(chunk.toArray)).map(new ByteBuffer(_))
 
   def byteDirect(capacity: Int): IO[IllegalArgumentException, ByteBuffer] =

--- a/src/main/scala/zio/nio/channels/AsynchronousFileChannel.scala
+++ b/src/main/scala/zio/nio/channels/AsynchronousFileChannel.scala
@@ -1,48 +1,38 @@
 package zio.nio.channels
 
-import java.nio.{ ByteBuffer => JByteBuffer }
-import java.nio.channels.{ CompletionHandler, FileLock, AsynchronousFileChannel => JAsynchronousFileChannel }
-
-import zio.{ Chunk, IO, Task, UIO }
-import java.nio.file.{ OpenOption, Path }
+import java.io.IOException
+import java.nio.channels.{ FileLock, AsynchronousFileChannel => JAsynchronousFileChannel }
 import java.nio.file.attribute.FileAttribute
+import java.nio.file.{ OpenOption, Path }
 import java.util.concurrent.ExecutorService
 
-import zio.interop.javaconcurrent._
-import zio.nio.Buffer
+import zio.nio.{ Buffer, ByteBuffer }
+import zio.{ Chunk, IO, UIO }
 
 import scala.collection.JavaConverters._
 
 class AsynchronousFileChannel(private val channel: JAsynchronousFileChannel) {
 
+  import AsynchronousChannel.wrap
+
   final def close: IO[Exception, Unit] =
     IO.effect(channel.close()).refineToOrDie[Exception]
 
-  final def force(metaData: Boolean): IO[Exception, Unit] =
-    IO.effect(channel.force(metaData)).refineToOrDie[Exception]
+  final def force(metaData: Boolean): IO[IOException, Unit] =
+    IO.effect(channel.force(metaData)).refineToOrDie[IOException]
 
-  final val lock: IO[Throwable, FileLock] =
-    Task.fromFutureJava(() => channel.lock())
+  final val lock: IO[Exception, FileLock] = wrap[FileLock](channel.lock((), _))
 
-  final def lock[A](attachment: A, handler: CompletionHandler[FileLock, A]): IO[Exception, Unit] =
-    IO.effect(channel.lock(attachment, handler)).refineToOrDie[Exception]
+  final def lock(position: Long, size: Long, shared: Boolean): IO[Exception, FileLock] =
+    wrap[FileLock](channel.lock(position, size, shared, (), _))
 
-  final def lock(position: Long, size: Long, shared: Boolean): IO[Throwable, FileLock] =
-    Task.fromFutureJava(() => channel.lock(position, size, shared))
+  final private[nio] def readBuffer(dst: ByteBuffer, position: Long): IO[Exception, Int] =
+    dst.withJavaBuffer { buf =>
+      wrap[Integer](channel.read(buf, position, (), _))
+        .map(_.intValue)
+    }
 
-  final def lock[A](
-    position: Long,
-    size: Long,
-    shared: Boolean,
-    attachment: A,
-    handler: CompletionHandler[FileLock, A]
-  ): IO[Exception, Unit] =
-    IO.effect(channel.lock(position, size, shared, attachment, handler)).refineToOrDie[Exception]
-
-  final private[nio] def readBuffer(dst: Buffer[Byte], position: Long): IO[Throwable, Integer] =
-    Task.fromFutureJava(() => channel.read(dst.buffer.asInstanceOf[JByteBuffer], position))
-
-  final def read(capacity: Int, position: Long): IO[Throwable, Chunk[Byte]] =
+  final def read(capacity: Int, position: Long): IO[Exception, Chunk[Byte]] =
     for {
       b <- Buffer.byte(capacity)
       _ <- readBuffer(b, position)
@@ -50,35 +40,11 @@ class AsynchronousFileChannel(private val channel: JAsynchronousFileChannel) {
       r = Chunk.fromArray(a)
     } yield r
 
-  final private[nio] def readBuffer[A](
-    dst: Buffer[Byte],
-    position: Long,
-    attachment: A,
-    handler: CompletionHandler[Integer, A]
-  ): IO[Exception, Unit] =
-    IO.effect(
-        channel.read(dst.buffer.asInstanceOf[JByteBuffer], position, attachment, handler)
-      )
-      .refineToOrDie[Exception]
+  final val size: IO[IOException, Long] =
+    IO.effect(channel.size()).refineToOrDie[IOException]
 
-  final def read[A](
-    capacity: Int,
-    position: Long,
-    attachment: A,
-    handler: CompletionHandler[Integer, A]
-  ): IO[Exception, Chunk[Byte]] =
-    for {
-      b <- Buffer.byte(capacity)
-      _ <- readBuffer(b, position, attachment, handler)
-      a <- b.array
-      r = Chunk.fromArray(a)
-    } yield r
-
-  final val size: IO[Exception, Long] =
-    IO.effect(channel.size()).refineToOrDie[Exception]
-
-  final def truncate(size: Long): IO[Exception, AsynchronousFileChannel] =
-    IO.effect(new AsynchronousFileChannel(channel.truncate(size))).refineToOrDie[Exception]
+  final def truncate(size: Long): IO[Exception, Unit] =
+    IO.effect(channel.truncate(size)).refineToOrDie[Exception].unit
 
   final val tryLock: IO[Exception, FileLock] =
     IO.effect(channel.tryLock()).refineToOrDie[Exception]
@@ -86,36 +52,17 @@ class AsynchronousFileChannel(private val channel: JAsynchronousFileChannel) {
   final def tryLock(position: Long, size: Long, shared: Boolean): IO[Exception, FileLock] =
     IO.effect(channel.tryLock(position, size, shared)).refineToOrDie[Exception]
 
-  final private[nio] def writeBuffer(src: Buffer[Byte], position: Long): IO[Throwable, Integer] =
-    Task.fromFutureJava(() => channel.write(src.buffer.asInstanceOf[JByteBuffer], position))
+  final private[nio] def writeBuffer(src: ByteBuffer, position: Long): IO[Exception, Int] =
+    src.withJavaBuffer { buf =>
+      wrap[Integer](channel.write(buf, position, (), _))
+        .map(_.intValue)
+    }
 
-  final def write(src: Chunk[Byte], position: Long): IO[Throwable, Integer] =
+  final def write(src: Chunk[Byte], position: Long): IO[Exception, Int] =
     for {
       b <- Buffer.byte(src)
       r <- writeBuffer(b, position)
     } yield r
-
-  final private[nio] def writeBuffer[A](
-    src: Buffer[Byte],
-    position: Long,
-    attachment: A,
-    handler: CompletionHandler[Integer, A]
-  ): IO[Exception, Unit] =
-    IO.effect(
-        channel.write(src.buffer.asInstanceOf[JByteBuffer], position, attachment, handler)
-      )
-      .refineToOrDie[Exception]
-
-  final def write[A](
-    src: Chunk[Byte],
-    position: Long,
-    attachment: A,
-    handler: CompletionHandler[Integer, A]
-  ): IO[Exception, Unit] =
-    for {
-      b <- Buffer.byte(src)
-      _ <- writeBuffer(b, position, attachment, handler)
-    } yield ()
 
   /**
    * Tells whether or not this channel is open.


### PR DESCRIPTION
* `java.util.concurrent.Future` is quite bad because it requires blocking to use. Fortunately each NIO API that returns a Java Future also has a non-blocking callback-based variant, which is better suited to ZIO. We should use the these non-blocking variants only.
* While the callback NIO APIs are preferable for internal use, there's no point exposing callbacks in our public APIs. Avoiding the need for callbacks is part of ZIO's value proposition.
* All these APIs can be safely refined to `Exception` error type rather than `Throwable`.
* Return unwrapped primitives as is the Scala idiom.
* `truncate` should have type `IO[Exception, Unit]`. Returning `this` doesn't make sense for ZIO.
