### PR TITLE
Add project homepage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 inThisBuild(
   List(
     organization := "dev.zio",
+    homepage := Some(url("https://github.com/zio/zio-nio/")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer("jdegoes", "John De Goes", "john@degoes.net", url("http://degoes.net"))


### PR DESCRIPTION
Adds github repository as `homepage`. The cause of this change is release `0.1.0` which was marked as "invalid POM" due to missing URL.