### PR TITLE
Add FileChannel and MappedByteBuffer.

### DIFF
--- a/docs/essentials/files.md
+++ b/docs/essentials/files.md
@@ -46,11 +46,11 @@ it's not in an effect. Apart from basic acquire/release actions Core API offers 
 for {
   channel <- channelM
 
-  isShared <- channel.lock.bracket(l => IO.effectTotal(l.release()))(l => IO.effectTotal(l.isShared))
+  isShared <- channel.lock().bracket(_.release.ignore)(l => IO.succeed(l.isShared))
   _ <- putStrLn(isShared.toString)                                      // false
 
-  managed = Managed.make(channel.lock(position = 0, size = 10, shared = false))(l => IO.effectTotal(l.release()))
-  isOverlaping <- managed.use(l => IO.effectTotal(l.overlaps(5, 20)))
+  managed = Managed.make(channel.lock(position = 0, size = 10, shared = false))(_.release.ignore)
+  isOverlaping <- managed.use(l => IO.succeed(l.overlaps(5, 20)))
   _ <- putStrLn(isOverlaping.toString)                                  // true
 } yield ()
 ```

--- a/src/main/scala/zio/nio/ByteBuffer.scala
+++ b/src/main/scala/zio/nio/ByteBuffer.scala
@@ -3,31 +3,31 @@ package zio.nio
 import zio.{ Chunk, IO, ZIO }
 import java.nio.{ BufferUnderflowException, ByteOrder, ReadOnlyBufferException, ByteBuffer => JByteBuffer }
 
-final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer) {
+class ByteBuffer protected[nio] (byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer) {
 
-  override protected[nio] def array: IO[UnsupportedOperationException, Array[Byte]] =
+  final override protected[nio] def array: IO[UnsupportedOperationException, Array[Byte]] =
     IO.effect(byteBuffer.array()).refineToOrDie[UnsupportedOperationException]
 
-  def order: ByteOrder = byteBuffer.order()
+  final def order: ByteOrder = byteBuffer.order()
 
-  override def slice: IO[Nothing, ByteBuffer] =
+  final override def slice: IO[Nothing, ByteBuffer] =
     IO.effectTotal(byteBuffer.slice()).map(new ByteBuffer(_))
 
-  override def compact: IO[ReadOnlyBufferException, Unit] =
+  final override def compact: IO[ReadOnlyBufferException, Unit] =
     IO.effect(byteBuffer.compact()).unit.refineToOrDie[ReadOnlyBufferException]
 
-  override def duplicate: IO[Nothing, ByteBuffer] =
+  final override def duplicate: IO[Nothing, ByteBuffer] =
     IO.effectTotal(new ByteBuffer(byteBuffer.duplicate()))
 
   def withJavaBuffer[R, E, A](f: JByteBuffer => ZIO[R, E, A]): ZIO[R, E, A] = f(byteBuffer)
 
-  override def get: IO[BufferUnderflowException, Byte] =
+  final override def get: IO[BufferUnderflowException, Byte] =
     IO.effect(byteBuffer.get()).refineToOrDie[BufferUnderflowException]
 
-  override def get(i: Int): IO[IndexOutOfBoundsException, Byte] =
+  final override def get(i: Int): IO[IndexOutOfBoundsException, Byte] =
     IO.effect(byteBuffer.get(i)).refineToOrDie[IndexOutOfBoundsException]
 
-  override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Byte]] =
+  final override def getChunk(maxLength: Int = Int.MaxValue): IO[BufferUnderflowException, Chunk[Byte]] =
     IO.effect {
         val array = Array.ofDim[Byte](math.min(maxLength, byteBuffer.remaining()))
         byteBuffer.get(array)
@@ -35,13 +35,13 @@ final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer)
       }
       .refineToOrDie[BufferUnderflowException]
 
-  override def put(element: Byte): IO[Exception, Unit] =
+  final override def put(element: Byte): IO[Exception, Unit] =
     IO.effect(byteBuffer.put(element)).unit.refineToOrDie[Exception]
 
-  override def put(index: Int, element: Byte): IO[Exception, Unit] =
+  final override def put(index: Int, element: Byte): IO[Exception, Unit] =
     IO.effect(byteBuffer.put(index, element)).unit.refineToOrDie[Exception]
 
-  override def putChunk(chunk: Chunk[Byte]): IO[Exception, Unit] =
+  final override def putChunk(chunk: Chunk[Byte]): IO[Exception, Unit] =
     IO.effect {
         val array = chunk.toArray
         byteBuffer.put(array)
@@ -49,96 +49,96 @@ final class ByteBuffer(byteBuffer: JByteBuffer) extends Buffer[Byte](byteBuffer)
       .unit
       .refineToOrDie[Exception]
 
-  override def asReadOnlyBuffer: IO[Nothing, ByteBuffer] =
+  final override def asReadOnlyBuffer: IO[Nothing, ByteBuffer] =
     IO.effectTotal(byteBuffer.asReadOnlyBuffer()).map(new ByteBuffer(_))
 
-  def asCharBuffer: IO[Nothing, CharBuffer] =
+  final def asCharBuffer: IO[Nothing, CharBuffer] =
     IO.effectTotal(new CharBuffer(byteBuffer.asCharBuffer()))
 
-  def asDoubleBuffer: IO[Nothing, DoubleBuffer] =
+  final def asDoubleBuffer: IO[Nothing, DoubleBuffer] =
     IO.effectTotal(new DoubleBuffer(byteBuffer.asDoubleBuffer()))
 
-  def asFloatBuffer: IO[Nothing, FloatBuffer] =
+  final def asFloatBuffer: IO[Nothing, FloatBuffer] =
     IO.effectTotal(new FloatBuffer(byteBuffer.asFloatBuffer()))
 
-  def asIntBuffer: IO[Nothing, IntBuffer] =
+  final def asIntBuffer: IO[Nothing, IntBuffer] =
     IO.effectTotal(new IntBuffer(byteBuffer.asIntBuffer()))
 
-  def asLongBuffer: IO[Nothing, LongBuffer] =
+  final def asLongBuffer: IO[Nothing, LongBuffer] =
     IO.effectTotal(new LongBuffer(byteBuffer.asLongBuffer()))
 
-  def asShortBuffer: IO[Nothing, ShortBuffer] =
+  final def asShortBuffer: IO[Nothing, ShortBuffer] =
     IO.effectTotal(new ShortBuffer(byteBuffer.asShortBuffer()))
 
-  def putChar(value: Char): IO[Exception, Unit] =
+  final def putChar(value: Char): IO[Exception, Unit] =
     IO.effect(byteBuffer.putChar(value)).unit.refineToOrDie[Exception]
 
-  def putChar(index: Int, value: Char): IO[Exception, Unit] =
+  final def putChar(index: Int, value: Char): IO[Exception, Unit] =
     IO.effect(byteBuffer.putChar(index, value)).unit.refineToOrDie[Exception]
 
-  def putDouble(value: Double): IO[Exception, Unit] =
+  final def putDouble(value: Double): IO[Exception, Unit] =
     IO.effect(byteBuffer.putDouble(value)).unit.refineToOrDie[Exception]
 
-  def putDouble(index: Int, value: Double): IO[Exception, Unit] =
+  final def putDouble(index: Int, value: Double): IO[Exception, Unit] =
     IO.effect(byteBuffer.putDouble(index, value)).unit.refineToOrDie[Exception]
 
-  def putFloat(value: Float): IO[Exception, Unit] =
+  final def putFloat(value: Float): IO[Exception, Unit] =
     IO.effect(byteBuffer.putFloat(value)).unit.refineToOrDie[Exception]
 
-  def putFloat(index: Int, value: Float): IO[Exception, Unit] =
+  final def putFloat(index: Int, value: Float): IO[Exception, Unit] =
     IO.effect(byteBuffer.putFloat(index, value)).unit.refineToOrDie[Exception]
 
-  def putInt(value: Int): IO[Exception, Unit] =
+  final def putInt(value: Int): IO[Exception, Unit] =
     IO.effect(byteBuffer.putInt(value)).unit.refineToOrDie[Exception]
 
-  def putInt(index: Int, value: Int): IO[Exception, Unit] =
+  final def putInt(index: Int, value: Int): IO[Exception, Unit] =
     IO.effect(byteBuffer.putInt(index, value)).unit.refineToOrDie[Exception]
 
-  def putLong(value: Long): IO[Exception, Unit] =
+  final def putLong(value: Long): IO[Exception, Unit] =
     IO.effect(byteBuffer.putLong(value)).unit.refineToOrDie[Exception]
 
-  def putLong(index: Int, value: Long): IO[Exception, Unit] =
+  final def putLong(index: Int, value: Long): IO[Exception, Unit] =
     IO.effect(byteBuffer.putLong(index, value)).unit.refineToOrDie[Exception]
 
-  def putShort(value: Short): IO[Exception, Unit] =
+  final def putShort(value: Short): IO[Exception, Unit] =
     IO.effect(byteBuffer.putShort(value)).unit.refineToOrDie[Exception]
 
-  def putShort(index: Int, value: Short): IO[Exception, Unit] =
+  final def putShort(index: Int, value: Short): IO[Exception, Unit] =
     IO.effect(byteBuffer.putShort(index, value)).unit.refineToOrDie[Exception]
 
-  def getChar: IO[BufferUnderflowException, Char] =
+  final def getChar: IO[BufferUnderflowException, Char] =
     IO.effect(byteBuffer.getChar()).refineToOrDie[BufferUnderflowException]
 
-  def getChar(index: Int): IO[IndexOutOfBoundsException, Char] =
+  final def getChar(index: Int): IO[IndexOutOfBoundsException, Char] =
     IO.effect(byteBuffer.getChar(index)).refineToOrDie[IndexOutOfBoundsException]
 
-  def getDouble: IO[BufferUnderflowException, Double] =
+  final def getDouble: IO[BufferUnderflowException, Double] =
     IO.effect(byteBuffer.getDouble()).refineToOrDie[BufferUnderflowException]
 
-  def getDouble(index: Int): IO[IndexOutOfBoundsException, Double] =
+  final def getDouble(index: Int): IO[IndexOutOfBoundsException, Double] =
     IO.effect(byteBuffer.getDouble(index)).refineToOrDie[IndexOutOfBoundsException]
 
-  def getFloat: IO[BufferUnderflowException, Float] =
+  final def getFloat: IO[BufferUnderflowException, Float] =
     IO.effect(byteBuffer.getFloat()).refineToOrDie[BufferUnderflowException]
 
-  def getFloat(index: Int): IO[IndexOutOfBoundsException, Float] =
+  final def getFloat(index: Int): IO[IndexOutOfBoundsException, Float] =
     IO.effect(byteBuffer.getFloat(index)).refineToOrDie[IndexOutOfBoundsException]
 
-  def getInt: IO[BufferUnderflowException, Int] =
+  final def getInt: IO[BufferUnderflowException, Int] =
     IO.effect(byteBuffer.getInt()).refineToOrDie[BufferUnderflowException]
 
-  def getInt(index: Int): IO[IndexOutOfBoundsException, Int] =
+  final def getInt(index: Int): IO[IndexOutOfBoundsException, Int] =
     IO.effect(byteBuffer.getInt(index)).refineToOrDie[IndexOutOfBoundsException]
 
-  def getLong: IO[BufferUnderflowException, Long] =
+  final def getLong: IO[BufferUnderflowException, Long] =
     IO.effect(byteBuffer.getLong()).refineToOrDie[BufferUnderflowException]
 
-  def getLong(index: Int): IO[IndexOutOfBoundsException, Long] =
+  final def getLong(index: Int): IO[IndexOutOfBoundsException, Long] =
     IO.effect(byteBuffer.getLong(index)).refineToOrDie[IndexOutOfBoundsException]
 
-  def getShort: IO[BufferUnderflowException, Short] =
+  final def getShort: IO[BufferUnderflowException, Short] =
     IO.effect(byteBuffer.getShort()).refineToOrDie[BufferUnderflowException]
 
-  def getShort(index: Int): IO[IndexOutOfBoundsException, Short] =
+  final def getShort(index: Int): IO[IndexOutOfBoundsException, Short] =
     IO.effect(byteBuffer.getShort(index)).refineToOrDie[IndexOutOfBoundsException]
 }

--- a/src/main/scala/zio/nio/MappedByteBuffer.scala
+++ b/src/main/scala/zio/nio/MappedByteBuffer.scala
@@ -1,0 +1,16 @@
+package zio.nio
+
+import java.nio.{ MappedByteBuffer => JMappedByteBuffer }
+
+import zio.{ IO, ZIO }
+import zio.blocking.Blocking
+
+final class MappedByteBuffer private[nio] (javaBuffer: JMappedByteBuffer) extends ByteBuffer(javaBuffer) {
+
+  def isLoaded: IO[Nothing, Boolean] = IO.effectTotal(javaBuffer.isLoaded)
+
+  def load: ZIO[Blocking, Nothing, Unit] = ZIO.accessM(_.blocking.blocking(IO.effectTotal(javaBuffer.load()).unit))
+
+  def force: ZIO[Blocking, Nothing, Unit] = ZIO.accessM(_.blocking.blocking(IO.effectTotal(javaBuffer.force()).unit))
+
+}

--- a/src/main/scala/zio/nio/channels/AsynchronousFileChannel.scala
+++ b/src/main/scala/zio/nio/channels/AsynchronousFileChannel.scala
@@ -30,11 +30,10 @@ class AsynchronousFileChannel(protected val channel: JAsynchronousFileChannel) e
 
   final def read(capacity: Int, position: Long): IO[Exception, Chunk[Byte]] =
     for {
-      b <- Buffer.byte(capacity)
-      _ <- readBuffer(b, position)
-      a <- b.array
-      r = Chunk.fromArray(a)
-    } yield r
+      b     <- Buffer.byte(capacity)
+      count <- readBuffer(b, position)
+      a     <- b.array
+    } yield Chunk.fromArray(a).take(math.max(count, 0))
 
   final val size: IO[IOException, Long] =
     IO.effect(channel.size()).refineToOrDie[IOException]

--- a/src/main/scala/zio/nio/channels/Channel.scala
+++ b/src/main/scala/zio/nio/channels/Channel.scala
@@ -1,0 +1,20 @@
+package zio.nio.channels
+
+import java.nio.channels.{ Channel => JChannel }
+
+import zio.{ IO, UIO }
+
+trait Channel {
+
+  protected val channel: JChannel
+
+  final def close: IO[Exception, Unit] =
+    IO.effect(channel.close()).refineToOrDie[Exception]
+
+  /**
+   * Tells whether or not this channel is open.
+   */
+  final def isOpen: UIO[Boolean] =
+    IO.effectTotal(channel.isOpen)
+
+}

--- a/src/main/scala/zio/nio/channels/FileChannel.scala
+++ b/src/main/scala/zio/nio/channels/FileChannel.scala
@@ -1,0 +1,86 @@
+package zio.nio.channels
+
+import java.io.IOException
+import java.nio.channels.{ FileChannel => JFileChannel }
+import java.nio.file.attribute.FileAttribute
+import java.nio.file.{ OpenOption, Path }
+
+import scala.collection.JavaConverters._
+import zio.{ IO, ZIO }
+import zio.blocking.Blocking
+import zio.nio.{ ByteBuffer, MappedByteBuffer }
+
+final class FileChannel private[channels] (override protected[channels] val channel: JFileChannel)
+    extends GatheringByteChannel
+    with ScatteringByteChannel {
+
+  def position: IO[IOException, Long] = IO.effect(channel.position()).refineToOrDie[IOException]
+
+  def size: IO[IOException, Long] = IO.effect(channel.size()).refineToOrDie[IOException]
+
+  def truncate(size: Long): ZIO[Blocking, Exception, Unit] =
+    ZIO.accessM[Blocking](_.blocking.effectBlocking(channel.truncate(size))).unit.refineToOrDie[Exception]
+
+  def force(metadata: Boolean): ZIO[Blocking, IOException, Unit] =
+    ZIO.accessM[Blocking](_.blocking.effectBlocking(channel.force(metadata))).refineToOrDie[IOException]
+
+  def transferTo(position: Long, count: Long, target: GatheringByteChannel): ZIO[Blocking, Exception, Long] =
+    ZIO
+      .accessM[Blocking](_.blocking.effectBlocking(channel.transferTo(position, count, target.channel)))
+      .refineToOrDie[Exception]
+
+  def transferFrom(src: ScatteringByteChannel, position: Long, count: Long): ZIO[Blocking, Exception, Long] =
+    ZIO
+      .accessM[Blocking](_.blocking.effectBlocking(channel.transferFrom(src.channel, position, count)))
+      .refineToOrDie[Exception]
+
+  def read(dst: ByteBuffer, position: Long): ZIO[Blocking, Exception, Int] =
+    ZIO
+      .accessM[Blocking] {
+        _.blocking.blocking {
+          dst.withJavaBuffer[Any, Throwable, Int](buffer => IO.effect(channel.read(buffer, position)))
+        }
+      }
+      .refineToOrDie[Exception]
+
+  def write(src: ByteBuffer, position: Long): ZIO[Blocking, Exception, Int] =
+    ZIO
+      .accessM[Blocking] {
+        _.blocking.blocking {
+          src.withJavaBuffer[Any, Throwable, Int](buffer => IO.effect(channel.write(buffer, position)))
+        }
+      }
+      .refineToOrDie[Exception]
+
+  def map(mode: JFileChannel.MapMode, position: Long, size: Long): ZIO[Blocking, Exception, MappedByteBuffer] =
+    ZIO
+      .accessM[Blocking](_.blocking.effectBlocking(new MappedByteBuffer(channel.map(mode, position, size))))
+      .refineToOrDie[Exception]
+
+  def lock(
+    position: Long = 0L,
+    size: Long = Long.MaxValue,
+    shared: Boolean = false
+  ): ZIO[Blocking, Exception, FileLock] =
+    ZIO
+      .accessM[Blocking](_.blocking.effectBlocking(new FileLock(channel.lock(position, size, shared))))
+      .refineToOrDie[Exception]
+
+  def tryLock(
+    position: Long = 0L,
+    size: Long = Long.MaxValue,
+    shared: Boolean = false
+  ): IO[Exception, Option[FileLock]] =
+    ZIO.effect(Option(channel.tryLock(position, size, shared)).map(new FileLock(_))).refineToOrDie[Exception]
+
+}
+
+object FileChannel {
+
+  def open(path: Path, options: Set[_ <: OpenOption], attrs: FileAttribute[_]*): IO[Exception, FileChannel] =
+    IO.effect(new FileChannel(JFileChannel.open(path, options.asJava, attrs: _*))).refineToOrDie[Exception]
+
+  def open(path: Path, options: OpenOption*): IO[Exception, FileChannel] =
+    IO.effect(new FileChannel(JFileChannel.open(path, options: _*))).refineToOrDie[Exception]
+
+}

--- a/src/main/scala/zio/nio/channels/FileChannel.scala
+++ b/src/main/scala/zio/nio/channels/FileChannel.scala
@@ -83,4 +83,11 @@ object FileChannel {
   def open(path: Path, options: OpenOption*): IO[Exception, FileChannel] =
     IO.effect(new FileChannel(JFileChannel.open(path, options: _*))).refineToOrDie[Exception]
 
+  type MapMode = JFileChannel.MapMode
+
+  object MapMode {
+    def READ_ONLY  = JFileChannel.MapMode.READ_ONLY
+    def READ_WRITE = JFileChannel.MapMode.READ_WRITE
+    def PRIVATE    = JFileChannel.MapMode.PRIVATE
+  }
 }

--- a/src/main/scala/zio/nio/channels/FileLock.scala
+++ b/src/main/scala/zio/nio/channels/FileLock.scala
@@ -1,0 +1,26 @@
+package zio.nio.channels
+
+import java.io.IOException
+import java.nio.channels.{ FileLock => JFileLock }
+
+import zio.{ IO, UIO }
+
+final class FileLock private[channels] (javaLock: JFileLock) {
+
+  def acquiredBy: Channel = new Channel {
+    override protected val channel = javaLock.acquiredBy
+  }
+
+  def position: Long = javaLock.position
+
+  def size: Long = javaLock.size
+
+  def isShared: Boolean = javaLock.isShared
+
+  def overlaps(position: Long, size: Long): Boolean = javaLock.overlaps(position, size)
+
+  def isValid: UIO[Boolean] = UIO.effectTotal(javaLock.isValid())
+
+  def release: IO[IOException, Unit] = IO.effect(javaLock.release()).refineToOrDie[IOException]
+
+}

--- a/src/main/scala/zio/nio/channels/Pipe.scala
+++ b/src/main/scala/zio/nio/channels/Pipe.scala
@@ -3,18 +3,27 @@ package zio.nio.channels
 import java.io.IOException
 import java.nio.channels.{ Pipe => JPipe }
 
+import zio.nio.channels
 import zio.{ IO, UIO }
 
 class Pipe(private val pipe: JPipe) {
 
-  final val source: UIO[ScatteringByteChannel] =
-    IO.effectTotal(new ScatteringByteChannel(pipe.source()))
+  final val source: UIO[Pipe.SourceChannel] =
+    IO.effectTotal(new channels.Pipe.SourceChannel(pipe.source()))
 
-  final val sink: UIO[GatheringByteChannel] =
-    IO.effectTotal(new GatheringByteChannel(pipe.sink()))
+  final val sink: UIO[Pipe.SinkChannel] =
+    IO.effectTotal(new Pipe.SinkChannel(pipe.sink()))
 }
 
 object Pipe {
+
+  final class SinkChannel(override protected[channels] val channel: JPipe.SinkChannel)
+      extends GatheringByteChannel
+      with SelectableChannel
+
+  final class SourceChannel(override protected[channels] val channel: JPipe.SourceChannel)
+      extends ScatteringByteChannel
+      with SelectableChannel
 
   final val open: IO[IOException, Pipe] =
     IO.effect(new Pipe(JPipe.open())).refineToOrDie[IOException]

--- a/src/test/scala/zio/nio/Main.scala
+++ b/src/test/scala/zio/nio/Main.scala
@@ -2,6 +2,13 @@ package zio.nio
 
 import testz._
 import runner.TestOutput
+import zio.nio.channels.{
+  AsynchronousChannelGroupSuite,
+  ChannelSuite,
+  FileChannelSuite,
+  ScatterGatherChannelSuite,
+  SelectorSuite
+}
 
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import ExecutionContext.global

--- a/src/test/scala/zio/nio/channels/AsynchronousChannelGroupSuite.scala
+++ b/src/test/scala/zio/nio/channels/AsynchronousChannelGroupSuite.scala
@@ -1,18 +1,15 @@
-package zio.nio
+package zio.nio.channels
 
 import java.nio.channels.{ AsynchronousChannelGroup => JAsynchronousChannelGroup }
-import java.util.concurrent.{ ExecutorService, TimeUnit }
+import java.util.concurrent.{ Executors, TimeUnit, ExecutorService => JExecutorService }
 
 import org.specs2.matcher.MustMatchers
+import testz.{ Result, _ }
 import zio.DefaultRuntime
 import zio.duration.Duration
-import testz.{ Result, _ }
-import java.util.concurrent.{ Executors, ExecutorService => JExecutorService }
-
-import zio.nio.channels.AsynchronousChannelGroup
 
 import scala.concurrent.Future
-import Future._
+import scala.concurrent.Future._
 
 object AsynchronousChannelGroupSuite extends DefaultRuntime with MustMatchers {
 
@@ -28,7 +25,7 @@ object AsynchronousChannelGroupSuite extends DefaultRuntime with MustMatchers {
 
     def apply(): Future[ClassFixture] = successful {
       new ClassFixture {
-        val jExecutor: ExecutorService = Executors.newFixedThreadPool(1)
+        val jExecutor: JExecutorService = Executors.newFixedThreadPool(1)
         val jChannelGroup: JAsynchronousChannelGroup =
           JAsynchronousChannelGroup.withThreadPool(jExecutor)
         val testObj = new AsynchronousChannelGroup(jChannelGroup)

--- a/src/test/scala/zio/nio/channels/ChannelSuite.scala
+++ b/src/test/scala/zio/nio/channels/ChannelSuite.scala
@@ -1,10 +1,8 @@
 package zio.nio.channels
 
-import zio.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
-import zio._
 import testz.{ Harness, assert }
 import zio.nio.{ Buffer, InetAddress, SocketAddress }
-import zio.{ DefaultRuntime, IO }
+import zio.{ DefaultRuntime, IO, _ }
 
 object ChannelSuite extends DefaultRuntime {
 

--- a/src/test/scala/zio/nio/channels/ChannelSuite.scala
+++ b/src/test/scala/zio/nio/channels/ChannelSuite.scala
@@ -1,8 +1,10 @@
-package zio.nio
+package zio.nio.channels
 
 import zio.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
 import zio._
 import testz.{ Harness, assert }
+import zio.nio.{ Buffer, InetAddress, SocketAddress }
+import zio.{ DefaultRuntime, IO }
 
 object ChannelSuite extends DefaultRuntime {
 

--- a/src/test/scala/zio/nio/channels/FileChannelSuite.scala
+++ b/src/test/scala/zio/nio/channels/FileChannelSuite.scala
@@ -1,10 +1,10 @@
-package zio.nio
+package zio.nio.channels
 
 import java.nio.file.{ Files, Paths, StandardOpenOption }
 
-import zio.{ Chunk, DefaultRuntime }
 import testz.{ Harness, assert }
-import zio.nio.channels.AsynchronousFileChannel
+import zio.nio.Buffer
+import zio.{ Chunk, DefaultRuntime }
 
 import scala.io.Source
 
@@ -18,7 +18,7 @@ object FileChannelSuite extends DefaultRuntime {
         val path = Paths.get("src/test/resources/async_file_read_test.txt")
 
         val testProgram = for {
-          channel <- AsynchronousFileChannel.open(path, Set(StandardOpenOption.READ))
+          channel <- AsynchronousFileChannel.open(path, StandardOpenOption.READ)
           buffer  <- Buffer.byte(16)
           _       <- channel.readBuffer(buffer, 0)
           _       <- buffer.flip
@@ -32,11 +32,10 @@ object FileChannelSuite extends DefaultRuntime {
         assert(result == "Hello World")
       },
       test("asynchronous file write") { () =>
-        val path    = Paths.get("src/test/resources/async_file_write_test.txt")
-        val options = Set(StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+        val path = Paths.get("src/test/resources/async_file_write_test.txt")
 
         val testProgram = for {
-          channel <- AsynchronousFileChannel.open(path, options)
+          channel <- AsynchronousFileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
           buffer  <- Buffer.byte(Chunk.fromArray("Hello World".getBytes))
           _       <- channel.writeBuffer(buffer, 0)
           _       <- channel.close

--- a/src/test/scala/zio/nio/channels/FileChannelSuite.scala
+++ b/src/test/scala/zio/nio/channels/FileChannelSuite.scala
@@ -62,6 +62,22 @@ object FileChannelSuite extends DefaultRuntime {
 
         assert(result.size == 1)
         assert(result.head == "Hello World")
+      },
+      test("memory mapped buffer") { () =>
+        val path = Paths.get("src/test/resources/async_file_read_test.txt")
+
+        val testProgram = {
+          FileChannel.open(path, StandardOpenOption.READ).bracket(_.close.ignore) { channel =>
+            for {
+              buffer <- channel.map(FileChannel.MapMode.READ_ONLY, 0L, 6L)
+              bytes  <- buffer.getChunk()
+            } yield bytes
+          }
+        }
+
+        val result = unsafeRun(testProgram)
+
+        assert(result == Chunk.fromArray("Hello ".getBytes(StandardCharsets.UTF_8)))
       }
     )
   }

--- a/src/test/scala/zio/nio/channels/FileChannelSuite.scala
+++ b/src/test/scala/zio/nio/channels/FileChannelSuite.scala
@@ -1,5 +1,6 @@
 package zio.nio.channels
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths, StandardOpenOption }
 
 import testz.{ Harness, assert }
@@ -14,7 +15,7 @@ object FileChannelSuite extends DefaultRuntime {
     import harness._
 
     section(
-      test("asynchronous file read") { () =>
+      test("asynchronous file buffer read") { () =>
         val path = Paths.get("src/test/resources/async_file_read_test.txt")
 
         val testProgram = for {
@@ -30,6 +31,19 @@ object FileChannelSuite extends DefaultRuntime {
         val result = unsafeRun(testProgram)
 
         assert(result == "Hello World")
+      },
+      test("asynchronous file chunk read") { () =>
+        val path = Paths.get("src/test/resources/async_file_read_test.txt")
+
+        val testProgram = for {
+          channel <- AsynchronousFileChannel.open(path, StandardOpenOption.READ)
+          bytes   <- channel.read(500, 0L)
+          _       <- channel.close
+        } yield bytes
+
+        val result = unsafeRun(testProgram)
+
+        assert(result == Chunk.fromArray("Hello World".getBytes(StandardCharsets.UTF_8)))
       },
       test("asynchronous file write") { () =>
         val path = Paths.get("src/test/resources/async_file_write_test.txt")

--- a/src/test/scala/zio/nio/channels/ScatterGatherChannelSuite.scala
+++ b/src/test/scala/zio/nio/channels/ScatterGatherChannelSuite.scala
@@ -1,10 +1,10 @@
-package zio.nio
+package zio.nio.channels
 
 import java.io.{ File, RandomAccessFile }
 
-import zio.nio.channels.{ GatheringByteChannel, ScatteringByteChannel }
-import zio.{ Chunk, DefaultRuntime, IO }
 import testz.{ Harness, assert }
+import zio.nio.Buffer
+import zio.{ Chunk, DefaultRuntime, IO }
 
 import scala.io.Source
 
@@ -27,7 +27,7 @@ object ScatterGatherChannelSuite extends DefaultRuntime {
 
         val testProgram = for {
           buffs   <- IO.collectAll(Seq(Buffer.byte(5), Buffer.byte(5)))
-          channel = new ScatteringByteChannel(fileChannel)
+          channel = new FileChannel(fileChannel)
           _       <- channel.readBuffer(buffs)
           list    <- IO.collectAll(buffs.map(readLine))
           _       <- channel.close
@@ -50,7 +50,7 @@ object ScatterGatherChannelSuite extends DefaultRuntime {
                       Buffer.byte(Chunk.fromArray("World".getBytes))
                     )
                   )
-          channel = new GatheringByteChannel(fileChannel)
+          channel = new FileChannel(fileChannel)
           _       <- channel.writeBuffer(buffs)
           _       <- channel.close
         } yield ()

--- a/src/test/scala/zio/nio/channels/SelectorSuite.scala
+++ b/src/test/scala/zio/nio/channels/SelectorSuite.scala
@@ -1,11 +1,11 @@
-package zio.nio
+package zio.nio.channels
 
 import java.nio.channels.{ CancelledKeyException, SelectionKey => JSelectionKey, SocketChannel => JSocketChannel }
 
+import testz.{ Harness, assert }
 import zio._
 import zio.clock.Clock
-import testz.{ Harness, assert }
-import zio.nio.channels.{ Selector, ServerSocketChannel, SocketChannel }
+import zio.nio.{ Buffer, SocketAddress }
 
 object SelectorSuite extends DefaultRuntime {
 


### PR DESCRIPTION
These classes are required to support memory mapped files. Most of the `FileChannel` APIs are blocking, so they require the ZIO Blocking module.

Other changes:

* Move test suite classes to the same package as the classes they test.
* Wrap the `FileLock` class, as this has side-effecting operations.
* Make `ScatteringByteChannel`, `GatheringByteChannel` and `SelectableChannel` into traits for classes that implement multiple of these.
