### PR TITLE
Use different test ports

### DIFF
--- a/nio/src/test/scala/zio/nio/channels/ChannelSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/ChannelSpec.scala
@@ -13,7 +13,7 @@ object ChannelSpec
       suite("ChannelSpec")(
         testM("read/write") {
           val inetAddress: ZIO[Any, Exception, InetSocketAddress] = InetAddress.localHost
-            .flatMap(iAddr => SocketAddress.inetSocketAddress(iAddr, 13370))
+            .flatMap(iAddr => SocketAddress.inetSocketAddress(iAddr, 13380))
 
           def echoServer(promise: Promise[Nothing, Unit]): IO[Exception, Unit] =
             for {
@@ -58,7 +58,7 @@ object ChannelSpec
         },
         testM("read should fail when connection close") {
           val inetAddress: ZIO[Any, Exception, InetSocketAddress] = InetAddress.localHost
-            .flatMap(iAddr => SocketAddress.inetSocketAddress(iAddr, 13372))
+            .flatMap(iAddr => SocketAddress.inetSocketAddress(iAddr, 13382))
 
           def server(started: Promise[Nothing, Unit]): IO[Exception, Fiber[Exception, Boolean]] =
             for {
@@ -98,7 +98,7 @@ object ChannelSpec
         },
         testM("close channel unbind port") {
           val inetAddress: ZIO[Any, Exception, InetSocketAddress] = InetAddress.localHost
-            .flatMap(iAddr => SocketAddress.inetSocketAddress(iAddr, 13376))
+            .flatMap(iAddr => SocketAddress.inetSocketAddress(iAddr, 13386))
 
           def client: IO[Exception, Unit] =
             for {

--- a/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
@@ -32,7 +32,7 @@ object SelectorSpecUtils {
   def byteArrayToString(array: Array[Byte]): String =
     array.takeWhile(_ != 10).map(_.toChar).mkString.trim
 
-  val addressIo = SocketAddress.inetSocketAddress("0.0.0.0", 1111)
+  val addressIo = SocketAddress.inetSocketAddress("0.0.0.0", 1112)
 
   def safeStatusCheck(statusCheck: IO[CancelledKeyException, Boolean]): IO[Nothing, Boolean] =
     statusCheck.either.map(_.getOrElse(false))


### PR DESCRIPTION
Running the tests over and over again seems to cause port contention.