### PR TITLE
Upgrade to rc19 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ install_jdk: &install_jdk
       command: |
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
         sudo add-apt-repository ppa:openjdk-r/ppa -y
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA
         sudo apt update
         sudo apt install openjdk-${JDK_VERSION}-jdk -y
 

--- a/examples/src/main/scala/StreamsBasedServer.scala
+++ b/examples/src/main/scala/StreamsBasedServer.scala
@@ -43,8 +43,9 @@ object StreamsBasedServer extends App {
                          .fromEffectOption(
                            channel.read(64).tap(_ => console.putStrLn("Read chunk")).orElse(ZIO.fail(None))
                          )
+                         .flattenChunks
                          .take(4)
-                         .transduce(ZSink.utf8DecodeChunk)
+                         .transduce(ZTransducer.utf8Decode)
                          .run(Sink.foldLeft("")(_ + (_: String)))
                 _ <- closeConn
                 _ <- f(data)

--- a/nio-core/src/main/scala/zio/nio/core/charset/package.scala
+++ b/nio-core/src/main/scala/zio/nio/core/charset/package.scala
@@ -6,7 +6,7 @@ import zio.stream.Sink
 
 package object charset {
 
-  def chunkCollectSink[A]: Sink[Nothing, Nothing, Chunk[A], Chunk[A]] =
+  def chunkCollectSink[A]: Sink[Nothing, Chunk[A], Chunk[A]] =
     Sink.foldLeft(Chunk[A]())(_ ++ _)
 
 }

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -17,7 +17,7 @@ object BuildHelper {
     incOptions ~= (_.withLogRecompileOnMacro(false))
   )
 
-  val ZioCoreVersion = "1.0.0-RC18-2"
+  val ZioCoreVersion = "1.0.0-RC19-2"
 
   private val Scala211 = "2.11.12"
   private val Scala212 = "2.12.10"


### PR DESCRIPTION
Added a `Chunk` where the signature required so, maybe we want to change the signature instead so that it requires a `Chunk[Byte]]` instead of `Chunk[Chunk[Byte]]` given the latest changes in ZStream.