### PR TITLE
Remove wrapper for SocketOption.

### DIFF
--- a/nio-core/src/main/scala/zio/nio/core/SocketOption.scala
+++ b/nio-core/src/main/scala/zio/nio/core/SocketOption.scala
@@ -1,5 +1,0 @@
-package zio.nio.core
-
-import java.net.{ SocketOption => JSocketOption }
-
-class SocketOption[T] private[nio] (private[nio] val jSocketOption: JSocketOption[T])

--- a/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
@@ -2,6 +2,7 @@ package zio.nio.core.channels
 
 import java.io.IOException
 import java.lang.{ Integer => JInteger, Long => JLong, Void => JVoid }
+import java.net.SocketOption
 import java.nio.channels.{
   AsynchronousByteChannel => JAsynchronousByteChannel,
   AsynchronousServerSocketChannel => JAsynchronousServerSocketChannel,
@@ -12,7 +13,7 @@ import java.util.concurrent.TimeUnit
 
 import zio.duration._
 import zio.interop.javaz._
-import zio.nio.core.{ Buffer, SocketAddress, SocketOption }
+import zio.nio.core.{ Buffer, SocketAddress }
 import zio.{ Chunk, IO, UIO, ZIO }
 
 class AsynchronousByteChannel(private val channel: JAsynchronousByteChannel) {
@@ -82,7 +83,7 @@ class AsynchronousServerSocketChannel(private val channel: JAsynchronousServerSo
     IO.effect(channel.bind(address.jSocketAddress, backlog)).refineToOrDie[Exception].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   /**
    * Accepts a connection.
@@ -143,7 +144,7 @@ class AsynchronousSocketChannel(private val channel: JAsynchronousSocketChannel)
     IO.effect(channel.bind(address.jSocketAddress)).refineToOrDie[Exception].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   final def shutdownInput: IO[Exception, Unit] =
     IO.effect(channel.shutdownInput()).refineToOrDie[Exception].unit

--- a/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
@@ -1,11 +1,11 @@
 package zio.nio.core.channels
 
 import java.io.IOException
-import java.net.{ DatagramSocket => JDatagramSocket, SocketAddress => JSocketAddress }
+import java.net.{ SocketOption, DatagramSocket => JDatagramSocket, SocketAddress => JSocketAddress }
 import java.nio.channels.{ DatagramChannel => JDatagramChannel }
 
 import zio.{ IO, UIO }
-import zio.nio.core.{ ByteBuffer, SocketAddress, SocketOption }
+import zio.nio.core.{ ByteBuffer, SocketAddress }
 
 /**
  * A [[java.nio.channels.DatagramChannel]] wrapper allowing for basic [[zio.ZIO]] interoperability.
@@ -104,7 +104,7 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the datagram channel with the given socket option set to the provided value
    */
   def setOption[T](name: SocketOption[T], value: T): IO[IOException, DatagramChannel] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[IOException].map(new DatagramChannel(_))
+    IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].map(new DatagramChannel(_))
 
   /**
    * Returns a reference to this channel's underlying datagram socket.

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
@@ -1,7 +1,7 @@
 package zio.nio.core.channels
 
 import java.io.IOException
-import java.net.{ ServerSocket => JServerSocket, Socket => JSocket }
+import java.net.{ SocketOption, ServerSocket => JServerSocket, Socket => JSocket }
 import java.nio.channels.{
   SelectableChannel => JSelectableChannel,
   ServerSocketChannel => JServerSocketChannel,
@@ -11,7 +11,7 @@ import java.nio.{ ByteBuffer => JByteBuffer }
 
 import zio.nio.core.channels.SelectionKey.Operation
 import zio.nio.core.channels.spi.SelectorProvider
-import zio.nio.core.{ Buffer, SocketAddress, SocketOption }
+import zio.nio.core.{ Buffer, SocketAddress }
 import zio.{ IO, UIO }
 
 trait SelectableChannel extends Channel {
@@ -65,7 +65,7 @@ final class SocketChannel(override protected[channels] val channel: JSocketChann
     IO.effect(channel.bind(local.jSocketAddress)).refineToOrDie[IOException].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   final val shutdownInput: IO[IOException, Unit] =
     IO.effect(channel.shutdownInput()).refineToOrDie[IOException].unit
@@ -123,7 +123,7 @@ final class ServerSocketChannel(override protected val channel: JServerSocketCha
     IO.effect(channel.bind(local.jSocketAddress, backlog)).refineToOrDie[IOException].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   final val socket: UIO[JServerSocket] =
     IO.effectTotal(channel.socket())

--- a/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
@@ -2,6 +2,7 @@ package zio.nio.channels
 
 import java.io.IOException
 import java.lang.{ Integer => JInteger, Long => JLong, Void => JVoid }
+import java.net.SocketOption
 import java.nio.channels.{
   AsynchronousByteChannel => JAsynchronousByteChannel,
   AsynchronousServerSocketChannel => JAsynchronousServerSocketChannel,
@@ -11,7 +12,7 @@ import java.nio.{ ByteBuffer => JByteBuffer }
 import java.util.concurrent.TimeUnit
 
 import zio.duration._
-import zio.nio.core.{ Buffer, SocketAddress, SocketOption }
+import zio.nio.core.{ Buffer, SocketAddress }
 import zio.nio.core.channels.AsynchronousChannelGroup
 import zio.{ Chunk, IO, Managed, UIO, ZIO }
 import zio.interop.javaz._
@@ -83,7 +84,7 @@ class AsynchronousServerSocketChannel(private val channel: JAsynchronousServerSo
     IO.effect(channel.bind(address.jSocketAddress, backlog)).refineToOrDie[Exception].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   /**
    * Accepts a connection.
@@ -155,7 +156,7 @@ class AsynchronousSocketChannel(private val channel: JAsynchronousSocketChannel)
     IO.effect(channel.bind(address.jSocketAddress)).refineToOrDie[Exception].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   final def shutdownInput: IO[Exception, Unit] =
     IO.effect(channel.shutdownInput()).refineToOrDie[Exception].unit

--- a/nio/src/main/scala/zio/nio/channels/DatagramChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/DatagramChannel.scala
@@ -1,11 +1,11 @@
 package zio.nio.channels
 
 import java.io.IOException
-import java.net.{ DatagramSocket => JDatagramSocket, SocketAddress => JSocketAddress }
+import java.net.{ SocketOption, DatagramSocket => JDatagramSocket, SocketAddress => JSocketAddress }
 import java.nio.channels.{ DatagramChannel => JDatagramChannel }
 
 import zio.{ IO, Managed, UIO }
-import zio.nio.core.{ ByteBuffer, SocketAddress, SocketOption }
+import zio.nio.core.{ ByteBuffer, SocketAddress }
 
 /**
  * A [[java.nio.channels.DatagramChannel]] wrapper allowing for idiomatic [[zio.ZIO]] interoperability.
@@ -91,7 +91,7 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the datagram channel with the given socket option set to the provided value
    */
   def setOption[T](name: SocketOption[T], value: T): IO[IOException, DatagramChannel] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[IOException].map(new DatagramChannel(_))
+    IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].map(new DatagramChannel(_))
 
   /**
    * Returns a reference to this channel's underlying datagram socket.

--- a/nio/src/main/scala/zio/nio/channels/SelectableChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/SelectableChannel.scala
@@ -1,7 +1,7 @@
 package zio.nio.channels
 
 import java.io.IOException
-import java.net.{ ServerSocket => JServerSocket, Socket => JSocket }
+import java.net.{ SocketOption, ServerSocket => JServerSocket, Socket => JSocket }
 import java.nio.channels.{
   SelectableChannel => JSelectableChannel,
   ServerSocketChannel => JServerSocketChannel,
@@ -10,7 +10,7 @@ import java.nio.channels.{
 import java.nio.{ ByteBuffer => JByteBuffer }
 
 import zio.nio.channels.spi.SelectorProvider
-import zio.nio.core.{ Buffer, SocketAddress, SocketOption }
+import zio.nio.core.{ Buffer, SocketAddress }
 import zio.nio.core.channels.SelectionKey
 import zio.nio.core.channels.SelectionKey.Operation
 import zio.{ IO, Managed, UIO }
@@ -66,7 +66,7 @@ final class SocketChannel private[channels] (override protected[channels] val ch
     IO.effect(channel.bind(local.jSocketAddress)).refineToOrDie[IOException].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   final val shutdownInput: IO[IOException, Unit] =
     IO.effect(channel.shutdownInput()).refineToOrDie[IOException].unit
@@ -136,7 +136,7 @@ final class ServerSocketChannel private (override protected val channel: JServer
     IO.effect(channel.bind(local.jSocketAddress, backlog)).refineToOrDie[IOException].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[Exception, Unit] =
-    IO.effect(channel.setOption(name.jSocketOption, value)).refineToOrDie[Exception].unit
+    IO.effect(channel.setOption(name, value)).refineToOrDie[Exception].unit
 
   final val socket: UIO[JServerSocket] =
     IO.effectTotal(channel.socket())


### PR DESCRIPTION
The current implementation offers no way to actually create the wrapper values required by our API. As the Java type is immutable and lacks any effectful operations, there does not seem to be a compelling need to wrap it at all.