### PR TITLE
Separate blocking and non/blocking APIs for SelectableChannel.

### DIFF
--- a/nio-core/src/main/scala/zio/nio/core/channels/FileChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/FileChannel.scala
@@ -20,8 +20,9 @@ import scala.collection.JavaConverters._
  * Read and write calls operate at the current position.
  */
 final class FileChannel private[channels] (override protected[channels] val channel: JFileChannel)
-    extends GatheringByteChannel
-    with ScatteringByteChannel {
+    extends GatheringByteChannel[Blocking]
+    with ScatteringByteChannel[Blocking]
+    with WithEnv.Blocking {
 
   def position: IO[IOException, Long] = IO.effect(channel.position()).refineToOrDie[IOException]
 
@@ -42,10 +43,10 @@ final class FileChannel private[channels] (override protected[channels] val chan
   def force(metadata: Boolean): ZIO[Blocking, IOException, Unit] =
     effectBlocking(channel.force(metadata)).refineToOrDie[IOException]
 
-  def transferTo(position: Long, count: Long, target: GatheringByteChannel): ZIO[Blocking, IOException, Long] =
+  def transferTo(position: Long, count: Long, target: GatheringByteChannel[_]): ZIO[Blocking, IOException, Long] =
     effectBlocking(channel.transferTo(position, count, target.channel)).refineToOrDie[IOException]
 
-  def transferFrom(src: ScatteringByteChannel, position: Long, count: Long): ZIO[Blocking, IOException, Long] =
+  def transferFrom(src: ScatteringByteChannel[_], position: Long, count: Long): ZIO[Blocking, IOException, Long] =
     effectBlocking(channel.transferFrom(src.channel, position, count)).refineToOrDie[IOException]
 
   def read(dst: ByteBuffer, position: Long): ZIO[Blocking, IOException, Int] =

--- a/nio-core/src/main/scala/zio/nio/core/channels/GatheringByteChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/GatheringByteChannel.scala
@@ -1,39 +1,43 @@
 package zio.nio.core.channels
 
 import java.io.IOException
-import java.nio.channels.{ GatheringByteChannel => JGatheringByteChannel }
 import java.nio.{ ByteBuffer => JByteBuffer }
+import java.nio.channels.{ GatheringByteChannel => JGatheringByteChannel }
 
+import zio.{ Chunk, IO, ZIO }
 import zio.nio.core.{ Buffer, ByteBuffer }
-import zio.{ Chunk, IO }
 
 /**
  * A channel that can write bytes from a sequence of buffers.
  */
-trait GatheringByteChannel extends Channel {
+trait GatheringByteChannel[R] extends Channel with WithEnv[R] {
 
   import GatheringByteChannel._
 
   override protected[channels] val channel: JGatheringByteChannel
 
-  final def write(srcs: List[ByteBuffer]): IO[IOException, Long] =
-    IO.effect(channel.write(unwrap(srcs))).refineToOrDie[IOException]
+  final def write(srcs: List[ByteBuffer]): ZIO[R, IOException, Long] =
+    withEnv {
+      IO.effect(channel.write(unwrap(srcs))).refineToOrDie[IOException]
+    }
 
-  final def write(src: ByteBuffer): IO[IOException, Int] =
-    IO.effect(channel.write(src.byteBuffer)).refineToOrDie[IOException]
+  final def write(src: ByteBuffer): ZIO[R, IOException, Int] =
+    withEnv {
+      IO.effect(channel.write(src.byteBuffer)).refineToOrDie[IOException]
+    }
 
   /**
    * Writes a list of chunks, in order.
    *
    * Multiple writes may be performed in order to write all the chunks.
    */
-  final def writeChunks(srcs: List[Chunk[Byte]]): IO[IOException, Unit] =
+  final def writeChunks(srcs: List[Chunk[Byte]]): ZIO[R, IOException, Unit] =
     for {
       bs <- IO.foreach(srcs)(Buffer.byte)
       _  <- {
         // Handle partial writes by dropping buffers where `hasRemaining` returns false,
         // meaning they've been completely written
-        def go(buffers: List[ByteBuffer]): IO[IOException, Unit] =
+        def go(buffers: List[ByteBuffer]): ZIO[R, IOException, Unit] =
           write(buffers).flatMap { _ =>
             IO.foreach(buffers)(b => b.hasRemaining.map(_ -> b)).flatMap { pairs =>
               val remaining = pairs.dropWhile(!_._1).map(_._2)
@@ -49,7 +53,7 @@ trait GatheringByteChannel extends Channel {
    *
    * Multiple writes may be performed to write the entire chunk.
    */
-  final def writeChunk(src: Chunk[Byte]): IO[IOException, Unit] = writeChunks(List(src))
+  final def writeChunk(src: Chunk[Byte]): ZIO[R, IOException, Unit] = writeChunks(List(src))
 
 }
 

--- a/nio-core/src/main/scala/zio/nio/core/channels/WithEnv.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/WithEnv.scala
@@ -1,0 +1,21 @@
+package zio.nio.core.channels
+
+import zio.{ IO, ZIO, blocking }
+
+private[channels] trait WithEnv[R] {
+
+  protected def withEnv[E, A](effect: IO[E, A]): ZIO[R, E, A]
+
+}
+
+private[channels] object WithEnv {
+
+  trait Blocking extends WithEnv[blocking.Blocking] {
+    override protected def withEnv[E, A](effect: IO[E, A]): ZIO[blocking.Blocking, E, A] = blocking.blocking(effect)
+  }
+
+  trait NonBlocking extends WithEnv[Any] {
+    override protected def withEnv[E, A](effect: IO[E, A]): ZIO[Any, E, A] = effect
+  }
+
+}

--- a/nio-core/src/main/scala/zio/nio/core/channels/spi/SelectorProvider.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/spi/SelectorProvider.scala
@@ -10,14 +10,15 @@ import zio.IO
 
 final class SelectorProvider(private val selectorProvider: JSelectorProvider) {
 
-  val openDatagramChannel: IO[IOException, DatagramChannel] =
-    IO.effect(DatagramChannel.fromJava(selectorProvider.openDatagramChannel())).refineToOrDie[IOException]
+  val openDatagramChannel: IO[IOException, DatagramChannel.Blocking] =
+    IO.effect(DatagramChannel.Blocking.fromJava(selectorProvider.openDatagramChannel())).refineToOrDie[IOException]
 
   // this can throw UnsupportedOperationException - doesn't seem like a recoverable exception
   def openDatagramChannel(
     family: ProtocolFamily
-  ): IO[IOException, DatagramChannel] =
-    IO.effect(DatagramChannel.fromJava(selectorProvider.openDatagramChannel(family))).refineToOrDie[IOException]
+  ): IO[IOException, DatagramChannel.Blocking] =
+    IO.effect(DatagramChannel.Blocking.fromJava(selectorProvider.openDatagramChannel(family)))
+      .refineToOrDie[IOException]
 
   val openPipe: IO[IOException, Pipe] =
     IO.effect(Pipe.fromJava(selectorProvider.openPipe())).refineToOrDie[IOException]
@@ -25,19 +26,20 @@ final class SelectorProvider(private val selectorProvider: JSelectorProvider) {
   val openSelector: IO[IOException, Selector] =
     IO.effect(new Selector(selectorProvider.openSelector())).refineToOrDie[IOException]
 
-  val openServerSocketChannel: IO[IOException, ServerSocketChannel] =
-    IO.effect(ServerSocketChannel.fromJava(selectorProvider.openServerSocketChannel())).refineToOrDie[IOException]
+  val openServerSocketChannel: IO[IOException, ServerSocketChannel.Blocking] =
+    IO.effect(ServerSocketChannel.Blocking.fromJava(selectorProvider.openServerSocketChannel()))
+      .refineToOrDie[IOException]
 
-  val openSocketChannel: IO[IOException, SocketChannel] =
-    IO.effect(new SocketChannel(selectorProvider.openSocketChannel())).refineToOrDie[IOException]
+  val openSocketChannel: IO[IOException, SocketChannel.Blocking] =
+    IO.effect(SocketChannel.Blocking.fromJava(selectorProvider.openSocketChannel())).refineToOrDie[IOException]
 
   val inheritedChannel: IO[IOException, Option[Channel]] =
     IO.effect(Option(selectorProvider.inheritedChannel()))
       .map {
         _.collect {
-          case c: jc.SocketChannel       => SocketChannel.fromJava(c)
-          case c: jc.ServerSocketChannel => ServerSocketChannel.fromJava(c)
-          case c: jc.DatagramChannel     => DatagramChannel.fromJava(c)
+          case c: jc.SocketChannel       => SocketChannel.Blocking.fromJava(c)
+          case c: jc.ServerSocketChannel => ServerSocketChannel.Blocking.fromJava(c)
+          case c: jc.DatagramChannel     => DatagramChannel.Blocking.fromJava(c)
           case c: jc.FileChannel         => FileChannel.fromJava(c)
         }
       }

--- a/nio-core/src/main/scala/zio/nio/core/file/WatchService.scala
+++ b/nio-core/src/main/scala/zio/nio/core/file/WatchService.scala
@@ -17,6 +17,8 @@ import zio.nio.core.IOCloseable
 
 import scala.jdk.CollectionConverters._
 
+import scala.jdk.CollectionConverters._
+
 trait Watchable {
   protected def javaWatchable: JWatchable
 

--- a/nio/src/main/scala/zio/nio/channels/SelectableChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/SelectableChannel.scala
@@ -10,7 +10,7 @@ import java.nio.channels.{
 
 import zio.{ IO, Managed, UIO }
 import zio.nio.channels.spi.SelectorProvider
-import zio.nio.core.{ SocketAddress }
+import zio.nio.core.SocketAddress
 import zio.nio.core.channels.SelectionKey
 import zio.nio.core.channels.SelectionKey.Operation
 

--- a/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
@@ -54,7 +54,7 @@ object SelectorSpec extends BaseSpec {
                             IO.whenM(safeStatusCheck(key.isReadable)) {
                               IO.effectSuspendTotal {
                                 val sClient = key.channel
-                                val client  = sClient.asInstanceOf[zio.nio.core.channels.SocketChannel]
+                                val client  = sClient.asInstanceOf[zio.nio.core.channels.SocketChannel.NonBlocking]
                                 for {
                                   _ <- client.read(buffer)
                                   _ <- buffer.flip


### PR DESCRIPTION
**WIP**

The `SelectableChannel` subclasses in NIO can all operate in either blocking or non-blocking mode. Java uses the same API for both modes, but there are some substantial differences in how this API works in each mode.

This makes the modal differences explicit in the types:

* Read and write methods require `zio.blocking.Blocking` when in blocking mode.
* Channel operations that are only useful in non-blocking mode are only defined for non-blocking channels.
* No need to return options for operations that always return a value when in blocking mode
* Blocking channels can't be used with `Selector`, whereas Java throws `IllegalBlockingMode` in this case
* Convenience methods to create channels in the mode you want
* It is still possible to change the blocking mode on the fly

`SelectorSpec` shows the use of both blocking and non-blocking APIs.
