### PR TITLE
Use ZManaged for resources in core

### DIFF
--- a/docs/essentials/charsets.md
+++ b/docs/essentials/charsets.md
@@ -59,7 +59,7 @@ import zio.ZIO
 
 // dump a file encoded in ISO8859 to the console
 
-FileChannel.open(Path("iso8859.txt")).bracket(_.close.ignore) { fileChan =>
+FileChannel.open(Path("iso8859.txt")).use { fileChan =>
   val inStream: ZStream[Blocking, Exception, Byte] = ZStream.repeatEffectChunkOption {
     fileChan.readChunk(1000).asSomeError.flatMap { chunk =>
       if (chunk.isEmpty) ZIO.fail(None) else ZIO.succeed(chunk)

--- a/docs/essentials/index.md
+++ b/docs/essentials/index.md
@@ -34,7 +34,8 @@ libraryDependencies += "dev.zio" %% "zio-nio" % "1.0.0-RC10"
 ## Main abstractions
 
  - **[File Channel](files.md)** — For processing files that are available locally. For every operation a new fiber is started to perform the operation.
- - **[Socket Channel](sockets.md)** — Provides an API for remote communication with `InetSocket`s. 
+ - **[Socket Channel](sockets.md)** — Provides anAPI for remote communication with `InetSocket`s. 
+ - **[Resource Management](resources.md)** - Avoiding resource leaks
  - **[Character Sets](charsets.md)** - For encoding or decoding character data.
 
 ## References

--- a/docs/essentials/index.md
+++ b/docs/essentials/index.md
@@ -34,7 +34,7 @@ libraryDependencies += "dev.zio" %% "zio-nio" % "1.0.0-RC10"
 ## Main abstractions
 
  - **[File Channel](files.md)** — For processing files that are available locally. For every operation a new fiber is started to perform the operation.
- - **[Socket Channel](sockets.md)** — Provides anAPI for remote communication with `InetSocket`s. 
+ - **[Socket Channel](sockets.md)** — Provides an API for remote communication with `InetSocket`s. 
  - **[Resource Management](resources.md)** - Avoiding resource leaks
  - **[Character Sets](charsets.md)** - For encoding or decoding character data.
 

--- a/docs/essentials/resources.md
+++ b/docs/essentials/resources.md
@@ -39,7 +39,7 @@ A scope is itself a managed resource. Other managed resources can be attached to
 ZManaged.scope.use { scope =>
 
   val channel: IO[IOException, SocketChannel] = scope(SocketChannel.open).map {
-    case (_ /* early release */, channel) => channel
+    case (earlyRelease @ _, channel) => channel
   }
 
   // use channel, perhaps with a Selector

--- a/docs/essentials/resources.md
+++ b/docs/essentials/resources.md
@@ -1,0 +1,66 @@
+---
+id: essentials_resources
+title:  "Resource Management"
+---
+
+NIO offers several objects, primarily channels, that consume resources (such as operating system file handles) that need to be released when no longer needed. If channels are not closed reliably, resource leaks can occur, causing a number of issues.
+
+For this reason, ZIO-NIO provides such resources using the [ZIO `ZManaged` API][zio-managed]. For example, calling `FileChannel.open` will produce a value of `ZManaged[Blocking, IOException, FileChannel]`. The file will not actually be opened until the managed value is *used*. 
+
+## Simple Usage
+
+The most straight-forward way to use a managed resource is with the `use` method:
+
+```scala mdoc:silent
+import zio._
+import zio.blocking.Blocking
+import zio.nio.core.channels._
+import zio.nio.core.file.Path
+import java.io.IOException
+
+def useChannel(f: FileChannel): ZIO[Blocking, IOException, Unit] = ???
+
+val effect: ZIO[Blocking, IOException, Unit] = FileChannel.open(Path("foo.txt"))
+  .use { fileChannel =>
+    // fileChannel is only valid in this lexical scope
+    useChannel(fileChannel)
+  }
+```
+
+In the above example, the `FileChannel` will be opened and then provided to the function passed to `use`. The channel will always be closed when the `use` function completes, regardless of whether the operation succeeds, fails, dies or is interrupted. As long as the channel is only used within the function passed to `use`, then we're guaranteed not to have leaks.
+
+## Flexible Resource Scoping
+
+Sometimes there are situations where `ZManaged#use` is too limiting, because the resource lifecycle needs to extend beyond a lexical scope. An example of this is registering channels with a `Selector`. How can we do this using `ZManaged` while still avoiding the possibility of leaks? One way is to use [the "scope" feature of `ZManaged`][zio-scope].
+
+A scope is itself a managed resource. Other managed resources can be attached to a scope, which gives them the same lifecycle as the scope. When the scope is released, all the other resources that have been attached to it will also be released.
+
+```scala mdoc:silent
+ZManaged.scope.use { scope =>
+
+  val channel: IO[IOException, SocketChannel] = scope(SocketChannel.open).map {
+    case (_ /* early release */, channel) => channel
+  }
+
+  // use channel, perhaps with a Selector
+  channel.flatMap(_.readChunk(10))
+
+}
+// the scope has now been released, as have all the resources attached to it
+```
+
+Note that `scope` returns both the resource and an "early release" effect. This allows you to release the resource before the scope exits, if you know it is no longer needed. This allows efficient use of the resource while still having the safety net of the scope to ensure the release happens even if there are failures, defects or interruptions.
+
+The `zio.nio.core.channels.SelectorSpec` test demonstrates the use of scoping to ensure nothing leaks if an error occurs.
+
+### Using `close` for Early Release
+
+In the case of channels, we don't actually need the early release features that `ZManaged` provides, as every channel has a built-in early release in the form of the `close` method. Closing a channel more than once is a perfectly safe thing to do, so you can use `close` to release a channel's resources early. When the `ZManaged` scope of the channel later ends, `close` will be called again, but it will be a no-op.
+
+## Manual Resource Management
+
+It is also possible to switch to completely manual resource management. [The `reserve` method][zio-reserve] can be called on any `ZManaged` value, which gives you the acquisition and release of the resource as two separate effect values that you can use as you like. If you use these reservation effects directly, it is entirely up to you to avoid leaking resources. This requires code to be written very carefully, and an understanding the finer details of how failures, defects and interruption work in ZIO.
+
+[zio-managed]: https://zio.dev/docs/datatypes/datatypes_managed
+[zio-scope]: https://javadoc.io/doc/dev.zio/zio_2.13/latest/zio/ZManaged$.html#scope:zio.Managed[Nothing,zio.ZManaged.Scope]
+[zio-reserve]: https://javadoc.io/doc/dev.zio/zio_2.13/latest/zio/ZManaged.html#reserve:zio.UIO[zio.Reservation[R,E,A]]

--- a/docs/essentials/sockets.md
+++ b/docs/essentials/sockets.md
@@ -11,7 +11,6 @@ Required imports for snippets:
 import zio._
 import zio.clock._
 import zio.console._
-import zio.nio._
 import zio.nio.channels._
 import zio.nio.core._
 ```

--- a/examples/src/main/scala/TextFileDump.scala
+++ b/examples/src/main/scala/TextFileDump.scala
@@ -33,7 +33,7 @@ object TextFileDump extends App {
   }
 
   private def dump(charset: Charset, file: Path): ZIO[Console with Blocking, Exception, Unit] =
-    FileChannel.open(file).bracket(_.close.ignore) { fileChan =>
+    FileChannel.open(file).use { fileChan =>
       val inStream: ZStream[Blocking, Exception, Byte] = ZStream.repeatEffectChunkOption {
         fileChan.readChunk(1000).asSomeError.flatMap { chunk =>
           if (chunk.isEmpty) ZIO.fail(None) else ZIO.succeed(chunk)

--- a/nio-core/src/main/scala/zio/nio/core/IOCloseable.scala
+++ b/nio-core/src/main/scala/zio/nio/core/IOCloseable.scala
@@ -1,0 +1,19 @@
+package zio.nio.core
+
+import java.io.IOException
+
+import zio.ZIO
+
+/**
+ * A resource with an effect to close or release the resource.
+ */
+trait IOCloseable {
+
+  type Env
+
+  /**
+   * Closes this resource.
+   */
+  def close: ZIO[Env, IOException, Unit]
+
+}

--- a/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
@@ -10,7 +10,7 @@ import java.nio.channels.{
 }
 import java.util.concurrent.TimeUnit
 
-import zio.{ Chunk, IO, Schedule, ZIO }
+import zio.{ Chunk, IO, Managed, Schedule, ZIO }
 import zio.clock.Clock
 import zio.duration._
 import zio.interop.javaz._
@@ -85,10 +85,11 @@ final class AsynchronousServerSocketChannel(protected val channel: JAsynchronous
   /**
    * Accepts a connection.
    */
-  val accept: IO[Exception, AsynchronousSocketChannel] =
+  val accept: Managed[Exception, AsynchronousSocketChannel] =
     effectAsyncWithCompletionHandler[JAsynchronousSocketChannel](h => channel.accept((), h))
       .map(AsynchronousSocketChannel.fromJava)
       .refineToOrDie[Exception]
+      .toNioManaged
 
   /**
    * The `SocketAddress` that the socket is bound to,
@@ -105,15 +106,17 @@ final class AsynchronousServerSocketChannel(protected val channel: JAsynchronous
 
 object AsynchronousServerSocketChannel {
 
-  def apply(): IO[IOException, AsynchronousServerSocketChannel] =
+  def open(): Managed[IOException, AsynchronousServerSocketChannel] =
     IO.effect(new AsynchronousServerSocketChannel(JAsynchronousServerSocketChannel.open()))
       .refineToOrDie[IOException]
+      .toNioManaged
 
-  def apply(
+  def open(
     channelGroup: AsynchronousChannelGroup
-  ): IO[IOException, AsynchronousServerSocketChannel] =
+  ): Managed[IOException, AsynchronousServerSocketChannel] =
     IO.effect(new AsynchronousServerSocketChannel(JAsynchronousServerSocketChannel.open(channelGroup.channelGroup)))
       .refineToOrDie[IOException]
+      .toNioManaged
 }
 
 class AsynchronousSocketChannel(override protected val channel: JAsynchronousSocketChannel)
@@ -208,13 +211,15 @@ class AsynchronousSocketChannel(override protected val channel: JAsynchronousSoc
 
 object AsynchronousSocketChannel {
 
-  def apply(): IO[IOException, AsynchronousSocketChannel] =
+  def open(): Managed[IOException, AsynchronousSocketChannel] =
     IO.effect(new AsynchronousSocketChannel(JAsynchronousSocketChannel.open()))
       .refineToOrDie[IOException]
+      .toNioManaged
 
-  def apply(channelGroup: AsynchronousChannelGroup): IO[IOException, AsynchronousSocketChannel] =
+  def open(channelGroup: AsynchronousChannelGroup): Managed[IOException, AsynchronousSocketChannel] =
     IO.effect(new AsynchronousSocketChannel(JAsynchronousSocketChannel.open(channelGroup.channelGroup)))
       .refineToOrDie[IOException]
+      .toNioManaged
 
   def fromJava(asyncSocketChannel: JAsynchronousSocketChannel): AsynchronousSocketChannel =
     new AsynchronousSocketChannel(asyncSocketChannel)

--- a/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
@@ -1,4 +1,5 @@
-package zio.nio.core.channels
+package zio.nio.core
+package channels
 
 import java.io.IOException
 import java.lang.{ Integer => JInteger, Long => JLong, Void => JVoid }
@@ -14,7 +15,6 @@ import zio.{ Chunk, IO, Managed, Schedule, ZIO }
 import zio.clock.Clock
 import zio.duration._
 import zio.interop.javaz._
-import zio.nio.core.{ Buffer, ByteBuffer, SocketAddress, eofCheck }
 
 /**
  * A byte channel that reads and writes asynchronously.

--- a/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousFileChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousFileChannel.scala
@@ -1,4 +1,5 @@
-package zio.nio.core.channels
+package zio.nio.core
+package channels
 
 import java.io.IOException
 import java.nio.channels.{ AsynchronousFileChannel => JAsynchronousFileChannel, FileLock => JFileLock }
@@ -7,7 +8,6 @@ import java.nio.file.OpenOption
 
 import zio.{ Chunk, IO, Managed }
 import zio.interop.javaz._
-import zio.nio.core.{ Buffer, ByteBuffer, eofCheck }
 import zio.nio.core.file.Path
 
 import scala.concurrent.ExecutionContextExecutorService

--- a/nio-core/src/main/scala/zio/nio/core/channels/Channel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/Channel.scala
@@ -3,9 +3,12 @@ package zio.nio.core.channels
 import java.io.IOException
 import java.nio.channels.{ Channel => JChannel }
 
+import zio.nio.core.IOCloseable
 import zio.{ IO, UIO }
 
-trait Channel {
+trait Channel extends IOCloseable {
+
+  type Env = Any
 
   protected val channel: JChannel
 

--- a/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 import java.net.{ SocketOption, DatagramSocket => JDatagramSocket, SocketAddress => JSocketAddress }
 import java.nio.channels.{ DatagramChannel => JDatagramChannel }
 
-import zio.{ IO, UIO }
+import zio.{ IO, Managed, UIO }
 import zio.nio.core.{ ByteBuffer, SocketAddress }
 
 /**
@@ -111,8 +111,10 @@ object DatagramChannel {
    *
    * @return a new datagram channel
    */
-  def open: IO[IOException, DatagramChannel] =
-    IO.effect(new DatagramChannel(JDatagramChannel.open())).refineToOrDie[IOException]
+  def open: Managed[IOException, DatagramChannel] =
+    IO.effect(new DatagramChannel(JDatagramChannel.open()))
+      .refineToOrDie[IOException]
+      .toNioManaged
 
   def fromJava(javaDatagramChannel: JDatagramChannel): DatagramChannel = new DatagramChannel(javaDatagramChannel)
 

--- a/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
@@ -1,11 +1,11 @@
-package zio.nio.core.channels
+package zio.nio.core
+package channels
 
 import java.io.IOException
 import java.net.{ SocketOption, DatagramSocket => JDatagramSocket, SocketAddress => JSocketAddress }
 import java.nio.channels.{ DatagramChannel => JDatagramChannel }
 
 import zio.{ IO, Managed, UIO }
-import zio.nio.core.{ ByteBuffer, SocketAddress }
 
 /**
  * A [[java.nio.channels.DatagramChannel]] wrapper allowing for basic [[zio.ZIO]] interoperability.

--- a/nio-core/src/main/scala/zio/nio/core/channels/FileChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/FileChannel.scala
@@ -8,8 +8,8 @@ import java.nio.file.attribute.FileAttribute
 import com.github.ghik.silencer.silent
 import zio.blocking.{ Blocking, _ }
 import zio.nio.core.file.Path
-import zio.nio.core.{ ByteBuffer, MappedByteBuffer }
-import zio.{ IO, ZIO }
+import zio.nio.core.{ ByteBuffer, IOCloseableManagement, MappedByteBuffer }
+import zio.{ IO, ZIO, ZManaged }
 
 import scala.collection.JavaConverters._
 
@@ -85,13 +85,15 @@ object FileChannel {
     path: Path,
     options: Set[_ <: OpenOption],
     attrs: FileAttribute[_]*
-  ): ZIO[Blocking, IOException, FileChannel] =
+  ): ZManaged[Blocking, IOException, FileChannel] =
     effectBlocking(new FileChannel(JFileChannel.open(path.javaPath, options.asJava, attrs: _*)))
       .refineToOrDie[IOException]
+      .toNioManaged
 
-  def open(path: Path, options: OpenOption*): ZIO[Blocking, IOException, FileChannel] =
+  def open(path: Path, options: OpenOption*): ZManaged[Blocking, IOException, FileChannel] =
     effectBlocking(new FileChannel(JFileChannel.open(path.javaPath, options: _*)))
       .refineToOrDie[IOException]
+      .toNioManaged
 
   def fromJava(javaFileChannel: JFileChannel): FileChannel = new FileChannel(javaFileChannel)
 

--- a/nio-core/src/main/scala/zio/nio/core/channels/Pipe.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/Pipe.scala
@@ -1,9 +1,9 @@
-package zio.nio.core.channels
+package zio.nio.core
+package channels
 
 import java.io.IOException
 import java.nio.channels.{ Pipe => JPipe }
 
-import zio.nio.core.channels
 import zio.{ IO, Managed }
 
 final class Pipe private (private val pipe: JPipe) {

--- a/nio-core/src/main/scala/zio/nio/core/channels/Pipe.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/Pipe.scala
@@ -4,15 +4,15 @@ import java.io.IOException
 import java.nio.channels.{ Pipe => JPipe }
 
 import zio.nio.core.channels
-import zio.{ IO, UIO }
+import zio.{ IO, Managed }
 
 final class Pipe private (private val pipe: JPipe) {
 
-  val source: UIO[Pipe.SourceChannel] =
-    IO.effectTotal(new channels.Pipe.SourceChannel(pipe.source()))
+  val source: Managed[Nothing, Pipe.SourceChannel] =
+    IO.effectTotal(new channels.Pipe.SourceChannel(pipe.source())).toNioManaged
 
-  val sink: UIO[Pipe.SinkChannel] =
-    IO.effectTotal(new Pipe.SinkChannel(pipe.sink()))
+  val sink: Managed[Nothing, Pipe.SinkChannel] =
+    IO.effectTotal(new Pipe.SinkChannel(pipe.sink())).toNioManaged
 }
 
 object Pipe {

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
@@ -8,7 +8,7 @@ import java.nio.channels.{
   SocketChannel => JSocketChannel
 }
 
-import zio.{ IO, UIO }
+import zio.{ IO, Managed, UIO }
 import zio.nio.core.channels.SelectionKey.Operation
 import zio.nio.core.channels.spi.SelectorProvider
 import zio.nio.core.SocketAddress
@@ -102,11 +102,11 @@ object SocketChannel {
 
   def fromJava(javaSocketChannel: JSocketChannel): SocketChannel = new SocketChannel(javaSocketChannel)
 
-  val open: IO[IOException, SocketChannel] =
-    IO.effect(new SocketChannel(JSocketChannel.open())).refineToOrDie[IOException]
+  val open: Managed[IOException, SocketChannel] =
+    IO.effect(new SocketChannel(JSocketChannel.open())).refineToOrDie[IOException].toNioManaged
 
-  def open(remote: SocketAddress): IO[IOException, SocketChannel] =
-    IO.effect(new SocketChannel(JSocketChannel.open(remote.jSocketAddress))).refineToOrDie[IOException]
+  def open(remote: SocketAddress): Managed[IOException, SocketChannel] =
+    IO.effect(new SocketChannel(JSocketChannel.open(remote.jSocketAddress))).refineToOrDie[IOException].toNioManaged
 }
 
 final class ServerSocketChannel(override protected val channel: JServerSocketChannel) extends SelectableChannel {
@@ -130,8 +130,12 @@ final class ServerSocketChannel(override protected val channel: JServerSocketCha
    *
    * @return None if this socket is in non-blocking mode and no connection is currently available to be accepted.
    */
-  def accept: IO[IOException, Option[SocketChannel]] =
-    IO.effect(Option(channel.accept()).map(new SocketChannel(_))).refineToOrDie[IOException]
+  def accept: Managed[IOException, Option[SocketChannel]] =
+    IO.effect(Option(channel.accept()).map(new SocketChannel(_)))
+      .refineToOrDie[IOException]
+      .toManaged(IO.whenCase(_) {
+        case Some(channel) => channel.close.ignore
+      })
 
   val localAddress: IO[IOException, SocketAddress] =
     IO.effect(new SocketAddress(channel.getLocalAddress())).refineToOrDie[IOException]
@@ -139,8 +143,8 @@ final class ServerSocketChannel(override protected val channel: JServerSocketCha
 
 object ServerSocketChannel {
 
-  val open: IO[IOException, ServerSocketChannel] =
-    IO.effect(new ServerSocketChannel(JServerSocketChannel.open())).refineToOrDie[IOException]
+  val open: Managed[IOException, ServerSocketChannel] =
+    IO.effect(new ServerSocketChannel(JServerSocketChannel.open())).refineToOrDie[IOException].toNioManaged
 
   def fromJava(javaChannel: JServerSocketChannel): ServerSocketChannel = new ServerSocketChannel(javaChannel)
 }

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
@@ -1,4 +1,5 @@
-package zio.nio.core.channels
+package zio.nio.core
+package channels
 
 import java.io.IOException
 import java.net.{ SocketOption, ServerSocket => JServerSocket, Socket => JSocket }
@@ -11,7 +12,6 @@ import java.nio.channels.{
 import zio.{ IO, Managed, UIO }
 import zio.nio.core.channels.SelectionKey.Operation
 import zio.nio.core.channels.spi.SelectorProvider
-import zio.nio.core.SocketAddress
 
 /**
  * A channel that can be multiplexed via a [[zio.nio.core.channels.Selector]].
@@ -126,7 +126,8 @@ final class ServerSocketChannel(override protected val channel: JServerSocketCha
   /**
    * Accepts a socket connection.
    *
-   * Not you must manually manage the lifecyle of the returned socket, calling `close` when you're finished with it.
+   * Note that the accept operation is not performed until the returned managed resource is
+   * actually used. `Managed.preallocate` can be used to preform the accept immediately.
    *
    * @return None if this socket is in non-blocking mode and no connection is currently available to be accepted.
    */

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
@@ -134,8 +134,8 @@ final class ServerSocketChannel(override protected val channel: JServerSocketCha
   def accept: Managed[IOException, Option[SocketChannel]] =
     IO.effect(Option(channel.accept()).map(new SocketChannel(_)))
       .refineToOrDie[IOException]
-      .toManaged(IO.whenCase(_) {
-        case Some(channel) => channel.close.ignore
+      .toManaged(IO.whenCase(_) { case Some(channel) =>
+        channel.close.ignore
       })
 
   val localAddress: IO[IOException, SocketAddress] =

--- a/nio-core/src/main/scala/zio/nio/core/channels/Selector.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/Selector.scala
@@ -1,11 +1,11 @@
-package zio.nio.core.channels
+package zio.nio.core
+package channels
 
 import java.io.IOException
 import java.nio.channels.{ SelectionKey => JSelectionKey, Selector => JSelector }
 
 import com.github.ghik.silencer.silent
 import zio.duration.Duration
-import zio.nio.core.IOCloseable
 import zio.nio.core.channels.spi.SelectorProvider
 import zio.{ IO, Managed, UIO }
 

--- a/nio-core/src/main/scala/zio/nio/core/file/FileSystem.scala
+++ b/nio-core/src/main/scala/zio/nio/core/file/FileSystem.scala
@@ -5,15 +5,19 @@ import java.net.URI
 import java.nio.file.attribute.UserPrincipalLookupService
 import java.nio.{ file => jf }
 
-import zio.blocking.{ Blocking, effectBlocking }
-import zio.{ UIO, ZIO }
+import zio.blocking.{ Blocking, effectBlocking, effectBlockingIO }
+import zio.nio.core.IOCloseable
+import zio.{ UIO, ZIO, ZManaged }
 
 import scala.jdk.CollectionConverters._
 
-final class FileSystem private (private val javaFileSystem: jf.FileSystem) {
+final class FileSystem private (private val javaFileSystem: jf.FileSystem) extends IOCloseable {
+
+  type Env = Blocking
+
   def provider: jf.spi.FileSystemProvider = javaFileSystem.provider()
 
-  def close: ZIO[Blocking, Exception, Unit] = effectBlocking(javaFileSystem.close()).refineToOrDie[Exception]
+  def close: ZIO[Blocking, IOException, Unit] = effectBlocking(javaFileSystem.close()).refineToOrDie[IOException]
 
   def isOpen: UIO[Boolean] = UIO.effectTotal(javaFileSystem.isOpen())
 
@@ -34,8 +38,8 @@ final class FileSystem private (private val javaFileSystem: jf.FileSystem) {
 
   def getUserPrincipalLookupService: UserPrincipalLookupService = javaFileSystem.getUserPrincipalLookupService
 
-  def newWatchService: ZIO[Blocking, IOException, WatchService] =
-    effectBlocking(WatchService.fromJava(javaFileSystem.newWatchService())).refineToOrDie[IOException]
+  def newWatchService: ZManaged[Blocking, IOException, WatchService] =
+    effectBlocking(WatchService.fromJava(javaFileSystem.newWatchService())).refineToOrDie[IOException].toNioManaged
 }
 
 object FileSystem {
@@ -46,15 +50,12 @@ object FileSystem {
   def getFileSystem(uri: URI): ZIO[Blocking, Exception, FileSystem] =
     effectBlocking(new FileSystem(jf.FileSystems.getFileSystem(uri))).refineToOrDie[Exception]
 
-  def newFileSystem(uri: URI, env: (String, Any)*): ZIO[Blocking, Exception, FileSystem] =
-    effectBlocking(new FileSystem(jf.FileSystems.newFileSystem(uri, env.toMap.asJava)))
-      .refineToOrDie[Exception]
+  def newFileSystem(uri: URI, env: (String, Any)*): ZManaged[Blocking, IOException, FileSystem] =
+    effectBlockingIO(new FileSystem(jf.FileSystems.newFileSystem(uri, env.toMap.asJava))).toNioManaged
 
-  def newFileSystem(uri: URI, env: Map[String, _], loader: ClassLoader): ZIO[Blocking, Exception, FileSystem] =
-    effectBlocking(new FileSystem(jf.FileSystems.newFileSystem(uri, env.asJava, loader)))
-      .refineToOrDie[Exception]
+  def newFileSystem(uri: URI, env: Map[String, _], loader: ClassLoader): ZManaged[Blocking, Exception, FileSystem] =
+    effectBlockingIO(new FileSystem(jf.FileSystems.newFileSystem(uri, env.asJava, loader))).toNioManaged
 
-  def newFileSystem(path: Path, loader: ClassLoader): ZIO[Blocking, Exception, FileSystem] =
-    effectBlocking(new FileSystem(jf.FileSystems.newFileSystem(path.javaPath, loader)))
-      .refineToOrDie[Exception]
+  def newFileSystem(path: Path, loader: ClassLoader): ZManaged[Blocking, IOException, FileSystem] =
+    effectBlockingIO(new FileSystem(jf.FileSystems.newFileSystem(path.javaPath, loader))).toNioManaged
 }

--- a/nio-core/src/main/scala/zio/nio/core/file/FileSystem.scala
+++ b/nio-core/src/main/scala/zio/nio/core/file/FileSystem.scala
@@ -1,4 +1,5 @@
-package zio.nio.core.file
+package zio.nio.core
+package file
 
 import java.io.IOException
 import java.net.URI
@@ -6,7 +7,6 @@ import java.nio.file.attribute.UserPrincipalLookupService
 import java.nio.{ file => jf }
 
 import zio.blocking.{ Blocking, effectBlocking, effectBlockingIO }
-import zio.nio.core.IOCloseable
 import zio.{ UIO, ZIO, ZManaged }
 
 import scala.jdk.CollectionConverters._

--- a/nio-core/src/main/scala/zio/nio/core/file/WatchService.scala
+++ b/nio-core/src/main/scala/zio/nio/core/file/WatchService.scala
@@ -76,8 +76,7 @@ final class WatchService private (private[file] val javaWatchService: JWatchServ
 
 object WatchService {
 
-  def forDefaultFileSystem: ZManaged[Blocking, IOException, WatchService] =
-    FileSystem.default.newWatchService
+  def forDefaultFileSystem: ZManaged[Blocking, IOException, WatchService] = FileSystem.default.newWatchService
 
   def fromJava(javaWatchService: JWatchService): WatchService = new WatchService(javaWatchService)
 }

--- a/nio-core/src/main/scala/zio/nio/core/file/WatchService.scala
+++ b/nio-core/src/main/scala/zio/nio/core/file/WatchService.scala
@@ -3,16 +3,17 @@ package zio.nio.core.file
 import java.io.IOException
 import java.nio.file.{
   WatchEvent,
+  Path => JPath,
   WatchKey => JWatchKey,
   WatchService => JWatchService,
-  Watchable => JWatchable,
-  Path => JPath
+  Watchable => JWatchable
 }
 import java.util.concurrent.TimeUnit
 
 import zio.blocking.Blocking
 import zio.duration.Duration
-import zio.{ IO, UIO, ZIO }
+import zio.nio.core.IOCloseable
+import zio.{ IO, UIO, ZIO, ZManaged }
 
 import scala.jdk.CollectionConverters._
 
@@ -55,7 +56,10 @@ final class WatchKey private[file] (private val javaKey: JWatchKey) {
     }
 }
 
-final class WatchService private (private[file] val javaWatchService: JWatchService) {
+final class WatchService private (private[file] val javaWatchService: JWatchService) extends IOCloseable {
+
+  type Env = Any
+
   def close: IO[IOException, Unit] = IO.effect(javaWatchService.close()).refineToOrDie[IOException]
 
   def poll: UIO[Option[WatchKey]] = IO.effectTotal(Option(javaWatchService.poll()).map(new WatchKey(_)))
@@ -71,7 +75,9 @@ final class WatchService private (private[file] val javaWatchService: JWatchServ
 }
 
 object WatchService {
-  def forDefaultFileSystem: ZIO[Blocking, IOException, WatchService] = FileSystem.default.newWatchService
+
+  def forDefaultFileSystem: ZManaged[Blocking, IOException, WatchService] =
+    FileSystem.default.newWatchService
 
   def fromJava(javaWatchService: JWatchService): WatchService = new WatchService(javaWatchService)
 }

--- a/nio-core/src/main/scala/zio/nio/core/package.scala
+++ b/nio-core/src/main/scala/zio/nio/core/package.scala
@@ -2,7 +2,7 @@ package zio.nio
 
 import java.io.EOFException
 
-import zio.{ IO, ZIO }
+import zio.{ IO, ZIO, ZManaged }
 
 package object core {
 
@@ -30,4 +30,11 @@ package object core {
       ZIO.none
     }
 
+  implicit final private[nio] class IOCloseableManagement[-R, +E, +A <: IOCloseable { type Env >: R }](
+    val acquire: ZIO[R, E, A]
+  ) extends AnyVal {
+
+    def toNioManaged: ZManaged[R, E, A] = acquire.toManaged[R](_.close.ignore)
+
+  }
 }

--- a/nio-core/src/test/scala/zio/nio/core/channels/ChannelSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/ChannelSpec.scala
@@ -1,5 +1,7 @@
 package zio.nio.core.channels
 
+import java.io.IOException
+
 import zio.nio.core.{ BaseSpec, Buffer, SocketAddress }
 import zio.test.{ suite, testM }
 import zio.{ IO, _ }
@@ -15,14 +17,14 @@ object ChannelSpec extends BaseSpec {
           for {
             address <- SocketAddress.inetSocketAddress(0)
             sink    <- Buffer.byte(3)
-            _       <- Managed
-                         .make(AsynchronousServerSocketChannel())(_.close.orDie)
+            _       <- AsynchronousServerSocketChannel
+                         .open()
                          .use { server =>
                            for {
                              _    <- server.bind(address)
                              addr <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
                              _    <- started.succeed(addr)
-                             _    <- Managed.make(server.accept)(_.close.orDie).use { worker =>
+                             _    <- server.accept.use { worker =>
                                        worker.read(sink) *>
                                          sink.flip *>
                                          worker.write(sink)
@@ -35,7 +37,7 @@ object ChannelSpec extends BaseSpec {
         def echoClient(address: SocketAddress): IO[Exception, Boolean] =
           for {
             src    <- Buffer.byte(3)
-            result <- Managed.make(AsynchronousSocketChannel())(_.close.orDie).use { client =>
+            result <- AsynchronousSocketChannel.open().use { client =>
                         for {
                           _        <- client.connect(address)
                           sent     <- src.array
@@ -59,15 +61,14 @@ object ChannelSpec extends BaseSpec {
         def server(started: Promise[Nothing, SocketAddress]): IO[Exception, Fiber[Exception, Boolean]] =
           for {
             address <- SocketAddress.inetSocketAddress(0)
-            result  <- Managed
-                         .make(AsynchronousServerSocketChannel())(_.close.orDie)
+            result  <- AsynchronousServerSocketChannel
+                         .open()
                          .use { server =>
                            for {
                              _      <- server.bind(address)
                              addr   <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
                              _      <- started.succeed(addr)
-                             result <- Managed
-                                         .make(server.accept)(_.close.orDie)
+                             result <- server.accept
                                          .use(worker => worker.readChunk(3) *> worker.readChunk(3) *> ZIO.succeed(false))
                                          .catchSome { case _: java.io.EOFException =>
                                            ZIO.succeed(true)
@@ -79,7 +80,7 @@ object ChannelSpec extends BaseSpec {
 
         def client(address: SocketAddress): IO[Exception, Unit] =
           for {
-            _ <- Managed.make(AsynchronousSocketChannel())(_.close.orDie).use { client =>
+            _ <- AsynchronousSocketChannel.open().use { client =>
                    for {
                      _ <- client.connect(address)
                      _  = client.writeChunk(Chunk.fromArray(Array[Byte](1, 1, 1)))
@@ -97,38 +98,32 @@ object ChannelSpec extends BaseSpec {
       },
       testM("close channel unbind port") {
         def client(address: SocketAddress): IO[Exception, Unit] =
-          for {
-            client <- AsynchronousSocketChannel()
-            _      <- client.connect(address)
-            _      <- client.close
-          } yield ()
+          AsynchronousSocketChannel.open().use {
+            _.connect(address)
+          }
 
         def server(
           address: SocketAddress,
           started: Promise[Nothing, SocketAddress]
-        ): IO[Exception, Fiber[Exception, Unit]] =
+        ): Managed[IOException, Fiber[Exception, Unit]] =
           for {
-            server <- AsynchronousServerSocketChannel()
-            _      <- server.bind(address)
-            addr   <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
-            _      <- started.succeed(addr)
-            worker <- server.accept
-                        .bracket(_.close.ignore *> server.close.ignore)(_ => ZIO.unit)
-                        .fork
+            server <- AsynchronousServerSocketChannel.open()
+            _      <- server.bind(address).toManaged_
+            addr   <- server.localAddress.someOrElseM(IO.die(new NoSuchElementException)).toManaged_
+            _      <- started.succeed(addr).toManaged_
+            worker <- server.accept.unit.fork
           } yield worker
 
         for {
-          address       <- SocketAddress.inetSocketAddress(0)
-          serverStarted <- Promise.make[Nothing, SocketAddress]
-          s1            <- server(address, serverStarted)
-          addr          <- serverStarted.await
-          _             <- client(addr)
-          _             <- s1.join
-          serverStarted <- Promise.make[Nothing, SocketAddress]
-          s2            <- server(addr, serverStarted)
-          _             <- serverStarted.await
-          _             <- client(addr)
-          _             <- s2.join
+          address        <- SocketAddress.inetSocketAddress(0)
+          serverStarted1 <- Promise.make[Nothing, SocketAddress]
+          _              <- server(address, serverStarted1).use { s1 =>
+                              serverStarted1.await.flatMap(client).zipRight(s1.join)
+                            }
+          serverStarted2 <- Promise.make[Nothing, SocketAddress]
+          _              <- server(address, serverStarted2).use { s2 =>
+                              serverStarted2.await.flatMap(client).zipRight(s2.join)
+                            }
         } yield assertCompletes
       }
     )

--- a/nio-core/src/test/scala/zio/nio/core/channels/DatagramChannelSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/DatagramChannelSpec.scala
@@ -1,5 +1,7 @@
 package zio.nio.core.channels
 
+import java.io.IOException
+
 import zio.nio.core._
 import zio.test.Assertion._
 import zio.test.{ suite, testM, _ }
@@ -10,30 +12,27 @@ object DatagramChannelSpec extends BaseSpec {
   override def spec =
     suite("DatagramChannelSpec")(
       testM("read/write") {
-        def echoServer(started: Promise[Nothing, SocketAddress]): IO[Exception, Unit] =
+        def echoServer(started: Promise[Nothing, SocketAddress]): IO[IOException, Unit] =
           for {
             address <- SocketAddress.inetSocketAddress(0)
             sink    <- Buffer.byte(3)
-            _       <- Managed
-                         .make(DatagramChannel.open)(_.close.orDie)
-                         .use { server =>
-                           for {
-                             _          <- server.bind(Some(address))
-                             addr       <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
-                             _          <- started.succeed(addr)
-                             retAddress <- server.receive(sink)
-                             addr       <- IO.fromOption(retAddress)
-                             _          <- sink.flip
-                             _          <- server.send(sink, addr)
-                           } yield ()
-                         }
-                         .fork
+            _       <- DatagramChannel.open.use { server =>
+                         for {
+                           _          <- server.bind(Some(address))
+                           addr       <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
+                           _          <- started.succeed(addr)
+                           retAddress <- server.receive(sink)
+                           addr       <- IO.fromOption(retAddress)
+                           _          <- sink.flip
+                           _          <- server.send(sink, addr)
+                         } yield ()
+                       }.fork
           } yield ()
 
-        def echoClient(address: SocketAddress): IO[Exception, Boolean] =
+        def echoClient(address: SocketAddress): IO[IOException, Boolean] =
           for {
             src    <- Buffer.byte(3)
-            result <- Managed.make(DatagramChannel.open)(_.close.orDie).use { client =>
+            result <- DatagramChannel.open.use { client =>
                         for {
                           _        <- client.connect(address)
                           sent     <- src.array
@@ -54,24 +53,21 @@ object DatagramChannelSpec extends BaseSpec {
         } yield assert(same)(isTrue)
       },
       testM("close channel unbind port") {
-        def client(address: SocketAddress): IO[Exception, Unit] =
-          Managed.make(DatagramChannel.open)(_.close.orDie).use(_.connect(address).unit)
+        def client(address: SocketAddress): IO[IOException, Unit] =
+          DatagramChannel.open.use(_.connect(address).unit)
 
         def server(
           address: SocketAddress,
           started: Promise[Nothing, SocketAddress]
-        ): IO[Exception, Fiber[Exception, Unit]] =
+        ): IO[Nothing, Fiber[IOException, Unit]] =
           for {
-            worker <- Managed
-                        .make(DatagramChannel.open)(_.close.orDie)
-                        .use { server =>
-                          for {
-                            _    <- server.bind(Some(address))
-                            addr <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
-                            _    <- started.succeed(addr)
-                          } yield ()
-                        }
-                        .fork
+            worker <- DatagramChannel.open.use { server =>
+                        for {
+                          _    <- server.bind(Some(address))
+                          addr <- server.localAddress.flatMap(opt => IO.effect(opt.get).orDie)
+                          _    <- started.succeed(addr)
+                        } yield ()
+                      }.fork
           } yield worker
 
         for {

--- a/nio-core/src/test/scala/zio/nio/core/channels/DatagramChannelSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/DatagramChannelSpec.scala
@@ -53,8 +53,7 @@ object DatagramChannelSpec extends BaseSpec {
         } yield assert(same)(isTrue)
       },
       testM("close channel unbind port") {
-        def client(address: SocketAddress): IO[IOException, Unit] =
-          DatagramChannel.open.use(_.connect(address).unit)
+        def client(address: SocketAddress): IO[IOException, Unit] = DatagramChannel.open.use(_.connect(address).unit)
 
         def server(
           address: SocketAddress,

--- a/nio-core/src/test/scala/zio/nio/core/channels/FileChannelSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/FileChannelSpec.scala
@@ -18,45 +18,47 @@ object FileChannelSpec extends BaseSpec {
     suite("FileChannelSpec")(
       testM("asynchronous file buffer read") {
         val path = Path("nio-core/src/test/resources/async_file_read_test.txt")
-        for {
-          channel <- AsynchronousFileChannel.open(path, StandardOpenOption.READ)
-          buffer  <- Buffer.byte(16)
-          _       <- channel.read(buffer, 0)
-          _       <- buffer.flip
-          array   <- buffer.array
-          text     = array.takeWhile(_ != 10).map(_.toChar).mkString.trim
-        } yield assert(text)(equalTo("Hello World"))
+        AsynchronousFileChannel.open(path, StandardOpenOption.READ).use { channel =>
+          for {
+            buffer <- Buffer.byte(16)
+            _      <- channel.read(buffer, 0)
+            _      <- buffer.flip
+            array  <- buffer.array
+            text    = array.takeWhile(_ != 10).map(_.toChar).mkString.trim
+          } yield assert(text)(equalTo("Hello World"))
+        }
       },
       testM("asynchronous file chunk read") {
         val path = Path("nio-core/src/test/resources/async_file_read_test.txt")
-        for {
-          channel <- AsynchronousFileChannel.open(path, StandardOpenOption.READ)
-          bytes   <- channel.readChunk(500, 0L)
-        } yield assert(bytes)(equalTo(Chunk.fromArray("Hello World".getBytes(StandardCharsets.UTF_8))))
+        AsynchronousFileChannel.open(path, StandardOpenOption.READ).use {
+          _.readChunk(500, 0L).map(assert(_)(equalTo(Chunk.fromArray("Hello World".getBytes(StandardCharsets.UTF_8)))))
+        }
       },
       testM("asynchronous file write") {
-        val path     = Path("nio-core/src/test/resources/async_file_write_test.txt")
-        val zChannel = AsynchronousFileChannel
+        val path = Path("nio-core/src/test/resources/async_file_write_test.txt")
+        AsynchronousFileChannel
           .open(
             path,
             StandardOpenOption.CREATE,
             StandardOpenOption.WRITE
           )
-        for {
-          channel <- zChannel
-          buffer  <- Buffer.byte(Chunk.fromArray("Hello World".getBytes))
-          _       <- channel.write(buffer, 0)
-          path    <- ZIO.effectTotal(Path("nio-core/src/test/resources/async_file_write_test.txt"))
-          result  <- ZIO.effect(Source.fromFile(path.toFile).getLines().toSeq)
-          _       <- ZIO.effect(Files.delete(path.javaPath))
-        } yield assert(result.size)(equalTo(1)) && assert(result.head)(equalTo("Hello World"))
+          .use { channel =>
+            for {
+              buffer <- Buffer.byte(Chunk.fromArray("Hello World".getBytes))
+              _      <- channel.write(buffer, 0)
+              path   <- ZIO.effectTotal(Path("nio-core/src/test/resources/async_file_write_test.txt"))
+              result <- ZIO.effect(Source.fromFile(path.toFile).getLines().toSeq)
+              _      <- ZIO.effect(Files.delete(path.javaPath))
+            } yield assert(result.size)(equalTo(1)) && assert(result.head)(equalTo("Hello World"))
+
+          }
       },
       testM("memory mapped buffer") {
         val path = Path("nio-core/src/test/resources/async_file_read_test.txt")
         for {
           result <- FileChannel
                       .open(path, StandardOpenOption.READ)
-                      .bracket(_.close.ignore) { channel =>
+                      .use { channel =>
                         for {
                           buffer <- channel.map(FileChannel.MapMode.READ_ONLY, 0L, 6L)
                           bytes  <- buffer.getChunk()
@@ -68,7 +70,7 @@ object FileChannelSpec extends BaseSpec {
         val path = Path("nio-core/src/test/resources/async_file_read_test.txt")
         FileChannel
           .open(path, StandardOpenOption.READ)
-          .bracket(_.close.ignore) { channel =>
+          .use { channel =>
             for {
               size <- channel.size
               _    <- channel.readChunk(size.toInt)

--- a/nio-core/src/test/scala/zio/nio/core/channels/SelectorSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/SelectorSpec.scala
@@ -47,9 +47,8 @@ object SelectorSpec extends BaseSpec {
                                 for {
                                   scopeResult     <- scope(channel.accept)
                                   (_, maybeClient) = scopeResult
-                                  _               <- IO.whenCase(maybeClient) {
-                                                       case Some(client) =>
-                                                         client.configureBlocking(false) *> client.register(selector, Operation.Read)
+                                  _               <- IO.whenCase(maybeClient) { case Some(client) =>
+                                                       client.configureBlocking(false) *> client.register(selector, Operation.Read)
                                                      }
                                 } yield ()
                               case client: SocketChannel if readyOps(Operation.Read)          =>

--- a/nio-core/src/test/scala/zio/nio/core/channels/SelectorSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/SelectorSpec.scala
@@ -17,7 +17,7 @@ object SelectorSpec extends BaseSpec {
       testM("read/write") {
         for {
           started     <- Promise.make[Nothing, SocketAddress]
-          serverFiber <- server(started).fork
+          serverFiber <- server(started).useNow.fork
           addr        <- started.await
           clientFiber <- client(addr).fork
           _           <- serverFiber.join
@@ -31,8 +31,9 @@ object SelectorSpec extends BaseSpec {
   def safeStatusCheck(statusCheck: IO[CancelledKeyException, Boolean]): IO[Nothing, Boolean] =
     statusCheck.fold(_ => false, identity)
 
-  def server(started: Promise[Nothing, SocketAddress]): ZIO[Clock with Blocking, Exception, Unit] = {
+  def server(started: Promise[Nothing, SocketAddress]): ZManaged[Clock with Blocking, Exception, Unit] = {
     def serverLoop(
+      scope: Managed.Scope,
       selector: Selector,
       buffer: ByteBuffer
     ): ZIO[Blocking, Exception, Unit] =
@@ -44,20 +45,20 @@ object SelectorSpec extends BaseSpec {
                             {
                               case channel: ServerSocketChannel if readyOps(Operation.Accept) =>
                                 for {
-                                  clientOpt <- channel.accept
-                                  client     = clientOpt.get
-                                  _         <- client.configureBlocking(false)
-                                  _         <- client.register(selector, Operation.Read)
+                                  scopeResult     <- scope(channel.accept)
+                                  (_, maybeClient) = scopeResult
+                                  _               <- IO.whenCase(maybeClient) {
+                                                       case Some(client) =>
+                                                         client.configureBlocking(false) *> client.register(selector, Operation.Read)
+                                                     }
                                 } yield ()
                               case client: SocketChannel if readyOps(Operation.Read)          =>
                                 for {
-                                  _     <- client.read(buffer)
-                                  array <- buffer.array
-                                  text   = byteArrayToString(array)
-                                  _     <- buffer.flip
-                                  _     <- client.write(buffer)
-                                  _     <- buffer.clear
-                                  _     <- client.close
+                                  _ <- client.read(buffer)
+                                  _ <- buffer.flip
+                                  _ <- client.write(buffer)
+                                  _ <- buffer.clear
+                                  _ <- client.close
                                 } yield ()
                             }
                           } *> selector.removeKey(key)
@@ -65,26 +66,27 @@ object SelectorSpec extends BaseSpec {
       } yield ()
 
     for {
-      address <- SocketAddress.inetSocketAddress(0)
-      _       <- Managed.make(Selector.make)(_.close.orDie).use { selector =>
-                   Managed.make(ServerSocketChannel.open)(_.close.orDie).use { channel =>
-                     for {
-                       _      <- channel.bind(address)
-                       _      <- channel.configureBlocking(false)
-                       _      <- channel.register(selector, Operation.Accept)
-                       buffer <- Buffer.byte(256)
-                       addr   <- channel.localAddress
-                       _      <- started.succeed(addr)
+      address  <- SocketAddress.inetSocketAddress(0).toManaged_
+      scope    <- Managed.scope
+      selector <- Selector.open
+      channel  <- ServerSocketChannel.open
+      _        <- Managed.fromEffect {
+                    for {
+                      _      <- channel.bind(address)
+                      _      <- channel.configureBlocking(false)
+                      _      <- channel.register(selector, Operation.Accept)
+                      buffer <- Buffer.byte(256)
+                      addr   <- channel.localAddress
+                      _      <- started.succeed(addr)
 
-                       /*
-                  *  we need to run the server loop twice:
-                  *  1. to accept the client request
-                  *  2. to read from the client channel
-                  */
-                       _ <- serverLoop(selector, buffer).repeat(Schedule.once)
-                     } yield ()
-                   }
-                 }
+                      /*
+                *  we need to run the server loop twice:
+                *  1. to accept the client request
+                *  2. to read from the client channel
+                */
+                      _ <- serverLoop(scope, selector, buffer).repeat(Schedule.once)
+                    } yield ()
+                  }
     } yield ()
   }
 
@@ -92,7 +94,7 @@ object SelectorSpec extends BaseSpec {
     val bytes = Chunk.fromArray("Hello world".getBytes)
     for {
       buffer <- Buffer.byte(bytes)
-      text   <- Managed.make(SocketChannel.open(address))(_.close.orDie).use { client =>
+      text   <- SocketChannel.open(address).use { client =>
                   for {
                     _     <- client.write(buffer)
                     _     <- buffer.clear

--- a/nio-core/src/test/scala/zio/nio/core/file/WathServiceSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/file/WathServiceSpec.scala
@@ -10,11 +10,12 @@ object WathServiceSpec extends BaseSpec {
   override def spec =
     suite("WatchServiceSpec")(
       testM("Watch Service register")(
-        for {
-          watchService <- FileSystem.default.newWatchService
-          watchKey     <- Path("nio-core/src/test/resources").register(watchService, ENTRY_CREATE)
-          watchable    <- watchKey.watchable
-        } yield assert(watchable)(equalTo(Path("nio-core/src/test/resources")))
+        FileSystem.default.newWatchService.use { watchService =>
+          for {
+            watchKey  <- Path("nio-core/src/test/resources").register(watchService, ENTRY_CREATE)
+            watchable <- watchKey.watchable
+          } yield assert(watchable)(equalTo(Path("nio-core/src/test/resources")))
+        }
       )
     )
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,6 +4,7 @@
       "essentials/essentials_index",
       "essentials/essentials_files",
       "essentials/essentials_sockets",
+      "essentials/essentials_resources",
       "essentials/essentials_charsets"
     ]
   },


### PR DESCRIPTION
The goal of this PR is to be a first step in undoing the split between the core and "high-level" modules. The split seemed like a good idea at the time, but in practice the only significant difference between the two modules is the high-level one uses `ZManaged`, whereas core requires the user to manually release resources using `close`. This minor difference comes at the cost of maintaining mostly duplicate copies of much of the code.

`ZManaged` was originally seen as too opinionated as a requirement to use ZIO-NIO. There are situations where lexically scoping resources with `use` is too limiting. However, `ZManaged` in ZIO 1.0 offers more flexible resource management via scopes or reservations, so a `ZManaged` based API shouldn't prevent ZIO-NIO from doing anything that can be done directly with NIO. So this PR makes all resource acquisition in core use `ZManaged`.

I've also left `close` as public, which probably seems odd. But `close` is still useful with `ZManaged` as an early release mechanism. While `ZManaged` lets you get an early release effect value, it's often more convenient to just have this effect available on the channel itself. For example, if we want to use the separate early release value with a channel registered in a selector, we have to attach it to the `SelectionKey` and later get the attachment and cast it to the correct type. But we already have a reference to the channel, so it's a lot simpler to just call `close` on it directly to release early.

`zio.nio.core.channels.SelectorSpec` provides an example of what I'm talking about above. I've also added a documentation page describing the resource management options. Hopefully what I've said is accurate 🤞 

If we decide to go this way, we can at some point throw out the high-level module and rename `zio.nio.core` to `zio.nio`.