### PR TITLE
Make AsynchronousServerSocketChannel#accept interruptible

### DIFF
--- a/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
@@ -87,7 +87,7 @@ class AsynchronousServerSocketChannel(private val channel: JAsynchronousServerSo
    */
   final val accept: Managed[Exception, AsynchronousSocketChannel] =
     Managed
-      .make(
+      .makeInterruptible(
         effectAsyncWithCompletionHandler[JAsynchronousSocketChannel](h => channel.accept((), h))
           .map(AsynchronousSocketChannel(_))
       )(_.close.orDie)

--- a/nio/src/test/scala/zio/nio/channels/ChannelSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/ChannelSpec.scala
@@ -124,6 +124,17 @@ object ChannelSpec extends BaseSpec {
           _             <- s2.join
         } yield assertCompletes
       },
+      testM("accept should be interruptible") {
+        AsynchronousServerSocketChannel().use { server =>
+          for {
+            addr   <- SocketAddress.inetSocketAddress(0)
+            _      <- server.bind(addr)
+            fiber  <- server.accept.useNow.fork
+            _      <- fiber.interrupt
+            result <- fiber.await
+          } yield assert(result)(isInterrupted)
+        }
+      },
       // this would best be tagged as an regression test. for now just run manually when suspicious.
       testM("accept should not leak resources") {
         val server          = for {


### PR DESCRIPTION
As we are currently using `ZManaged#make`, `accept` is uninterruptible and can result in hard to diagnose issues.