### PR TITLE
Improve InetSocketAddress and socket binding APIs.

### DIFF
--- a/examples/src/main/scala/StreamsBasedServer.scala
+++ b/examples/src/main/scala/StreamsBasedServer.scala
@@ -3,7 +3,7 @@ import zio.clock.Clock
 import zio.console.Console
 import zio.duration._
 import zio.nio.channels._
-import zio.nio.core.SocketAddress
+import zio.nio.core.InetSocketAddress
 import zio.stream._
 
 object StreamsBasedServer extends App {
@@ -16,7 +16,7 @@ object StreamsBasedServer extends App {
     AsynchronousServerSocketChannel()
       .use(socket =>
         for {
-          _ <- SocketAddress.inetSocketAddress("localhost", port) >>= socket.bind
+          _ <- InetSocketAddress.hostname("localhost", port).flatMap(socket.bindTo(_))
           _ <- ZStream
                  .repeatEffect(socket.accept.preallocate)
                  .map(_.withEarlyRelease)

--- a/examples/src/main/scala/StreamsBasedServer.scala
+++ b/examples/src/main/scala/StreamsBasedServer.scala
@@ -16,7 +16,7 @@ object StreamsBasedServer extends App {
     AsynchronousServerSocketChannel()
       .use(socket =>
         for {
-          _ <- InetSocketAddress.hostname("localhost", port).flatMap(socket.bindTo(_))
+          _ <- InetSocketAddress.hostName("localhost", port).flatMap(socket.bindTo(_))
           _ <- ZStream
                  .repeatEffect(socket.accept.preallocate)
                  .map(_.withEarlyRelease)

--- a/nio-core/src/main/scala/zio/nio/core/InetAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetAddress.scala
@@ -42,7 +42,7 @@ final class InetAddress private[nio] (private[nio] val jInetAddress: JInetAddres
     IO.effect(jInetAddress.isReachable(networkInterface.jNetworkInterface, ttl, timeout))
       .refineToOrDie[IOException]
 
-  def hostname: String = jInetAddress.getHostName
+  def hostName: String = jInetAddress.getHostName
 
   def canonicalHostName: String = jInetAddress.getCanonicalHostName
 

--- a/nio-core/src/main/scala/zio/nio/core/InetAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetAddress.scala
@@ -46,7 +46,7 @@ final class InetAddress private[nio] (private[nio] val jInetAddress: JInetAddres
 
   def canonicalHostName: String = jInetAddress.getCanonicalHostName
 
-  def address: Array[Byte] = jInetAddress.getAddress
+  def address: Chunk[Byte] = Chunk.fromArray(jInetAddress.getAddress)
 
   override def hashCode(): Int = jInetAddress.hashCode()
 

--- a/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
@@ -121,8 +121,8 @@ object InetSocketAddress {
    *
    * If the hostname cannot be resolved, fails with `UnknownHostException`.
    */
-  def hostnameResolved(hostname: String, port: Int): IO[UnknownHostException, InetSocketAddress] =
-    InetAddress.byName(hostname).flatMap(inetAddress(_, port))
+  def hostNameResolved(hostName: String, port: Int): IO[UnknownHostException, InetSocketAddress] =
+    InetAddress.byName(hostName).flatMap(inetAddress(_, port))
 
   /**
    * Creates a socket address from a hostname, with an ephemeral port.
@@ -130,15 +130,15 @@ object InetSocketAddress {
    * This method will attempt to resolve the hostname; if this fails, the returned
    * socket address will be ''unresolved''.
    */
-  def hostnameEphemeral(hostname: String): UIO[InetSocketAddress] = this.hostName(hostname, 0)
+  def hostNameEphemeral(hostName: String): UIO[InetSocketAddress] = this.hostName(hostName, 0)
 
   /**
    * Creates a resolved socket address from a hostname, with an ephemeral port.
    *
    * If the hostname cannot be resolved, fails with `UnknownHostException`.
    */
-  def hostnameEphemeralResolved(hostname: String): IO[UnknownHostException, InetSocketAddress] =
-    InetAddress.byName(hostname).flatMap(inetAddressEphemeral)
+  def hostNameEphemeralResolved(hostName: String): IO[UnknownHostException, InetSocketAddress] =
+    InetAddress.byName(hostName).flatMap(inetAddressEphemeral)
 
   /**
    * Creates a socket address from an IP address and a port number.
@@ -163,8 +163,8 @@ object InetSocketAddress {
    * No attempt will be made to resolve the hostname into an `InetAddress`.
    * The socket address will be flagged as ''unresolved''.
    */
-  def unresolvedHostname(hostname: String, port: Int): UIO[InetSocketAddress] =
-    UIO.effectTotal(new InetSocketAddress(JInetSocketAddress.createUnresolved(hostname, port)))
+  def unresolvedHostName(hostName: String, port: Int): UIO[InetSocketAddress] =
+    UIO.effectTotal(new InetSocketAddress(JInetSocketAddress.createUnresolved(hostName, port)))
 
   /**
    * Creates an unresolved socket address from a hostname using an ephemeral port.
@@ -172,6 +172,6 @@ object InetSocketAddress {
    * No attempt will be made to resolve the hostname into an `InetAddress`.
    * The socket address will be flagged as ''unresolved''.
    */
-  def unresolvedHostnameEphemeral(hostname: String): UIO[InetSocketAddress] = unresolvedHostname(hostname, 0)
+  def unresolvedHostNameEphemeral(hostName: String): UIO[InetSocketAddress] = unresolvedHostName(hostName, 0)
 
 }

--- a/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
@@ -113,8 +113,8 @@ object InetSocketAddress {
    * This method will attempt to resolve the hostname; if this fails, the returned
    * socket address will be ''unresolved''.
    */
-  def hostname(hostname: String, port: Int): UIO[InetSocketAddress] =
-    UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(hostname, port)))
+  def hostName(hostName: String, port: Int): UIO[InetSocketAddress] =
+    UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(hostName, port)))
 
   /**
    * Creates a resolved socket address from a hostname and port number.
@@ -130,7 +130,7 @@ object InetSocketAddress {
    * This method will attempt to resolve the hostname; if this fails, the returned
    * socket address will be ''unresolved''.
    */
-  def hostnameEphemeral(hostname: String): UIO[InetSocketAddress] = this.hostname(hostname, 0)
+  def hostnameEphemeral(hostname: String): UIO[InetSocketAddress] = this.hostName(hostname, 0)
 
   /**
    * Creates a resolved socket address from a hostname, with an ephemeral port.

--- a/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
@@ -22,6 +22,18 @@ sealed class SocketAddress private[nio] (private[nio] val jSocketAddress: JSocke
   final override def toString: String = jSocketAddress.toString
 }
 
+object SocketAddress {
+
+  def fromJava(jSocketAddress: JSocketAddress): SocketAddress =
+    jSocketAddress match {
+      case inet: JInetSocketAddress =>
+        new InetSocketAddress(inet)
+      case other                    =>
+        new SocketAddress(other)
+    }
+
+}
+
 /**
  * Representation of an IP Socket Address (IP address + port number).
  *
@@ -75,29 +87,26 @@ final class InetSocketAddress private[nio] (private val jInetSocketAddress: JIne
 
 }
 
-object SocketAddress {
-
-  private[nio] def fromJava(jSocketAddress: JSocketAddress) =
-    jSocketAddress match {
-      case inet: JInetSocketAddress =>
-        new InetSocketAddress(inet)
-      case other                    =>
-        new SocketAddress(other)
-    }
+object InetSocketAddress {
 
   /**
    * Creates a socket address where the IP address is the wildcard address and the port number a specified value.
    *
    * The socket address will be ''resolved''.
    */
-  def inetSocketAddress(port: Int): UIO[InetSocketAddress] = InetSocketAddress(port)
+  def wildCard(port: Int): UIO[InetSocketAddress] = UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(port)))
+
+  def wildCardEphemeral: UIO[InetSocketAddress] = wildCard(0)
 
   /**
    * Creates a socket address from an IP address and a port number.
    *
    * The socket address will be ''resolved''.
    */
-  def inetSocketAddress(hostname: String, port: Int): UIO[InetSocketAddress] = InetSocketAddress(hostname, port)
+  def hostname(hostname: String, port: Int): UIO[InetSocketAddress] =
+    UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(hostname, port)))
+
+  def hostnameEphemeral(hostname: String): UIO[InetSocketAddress] = this.hostname(hostname, 0)
 
   /**
    * Creates a socket address from a hostname and a port number.
@@ -105,7 +114,10 @@ object SocketAddress {
    * An attempt will be made to resolve the hostname into an `InetAddress`.
    * If that attempt fails, the socket address will be flagged as ''unresolved''.
    */
-  def inetSocketAddress(address: InetAddress, port: Int): UIO[InetSocketAddress] = InetSocketAddress(address, port)
+  def inetAddress(address: InetAddress, port: Int): UIO[InetSocketAddress] =
+    UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(address.jInetAddress, port)))
+
+  def inetAddressEphemeral(address: InetAddress): UIO[InetSocketAddress] = inetAddress(address, 0)
 
   /**
    * Creates an unresolved socket address from a hostname and a port number.
@@ -113,21 +125,9 @@ object SocketAddress {
    * No attempt will be made to resolve the hostname into an `InetAddress`.
    * The socket address will be flagged as ''unresolved''.
    */
-  def unresolvedInetSocketAddress(hostname: String, port: Int): UIO[InetSocketAddress] =
-    InetSocketAddress.createUnresolved(hostname, port)
+  def unresolvedHostname(hostname: String, port: Int): UIO[InetSocketAddress] =
+    UIO.effectTotal(new InetSocketAddress(JInetSocketAddress.createUnresolved(hostname, port)))
 
-  private object InetSocketAddress {
+  def unresolvedHostnameEphemeral(hostname: String): UIO[InetSocketAddress] = unresolvedHostname(hostname, 0)
 
-    def apply(port: Int): UIO[InetSocketAddress] = UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(port)))
-
-    def apply(host: String, port: Int): UIO[InetSocketAddress] =
-      UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(host, port)))
-
-    def apply(addr: InetAddress, port: Int): UIO[InetSocketAddress] =
-      UIO.effectTotal(new InetSocketAddress(new JInetSocketAddress(addr.jInetAddress, port)))
-
-    def createUnresolved(host: String, port: Int): UIO[InetSocketAddress] =
-      UIO.effectTotal(new InetSocketAddress(JInetSocketAddress.createUnresolved(host, port)))
-
-  }
 }

--- a/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
@@ -103,7 +103,7 @@ object InetSocketAddress {
    * Creates a socket address where the IP address is the wildcard address and
    * the port is ephemeral.
    *
-   * The socket address wll be ''resolved''.
+   * The socket address will be ''resolved''.
    */
   def wildCardEphemeral: UIO[InetSocketAddress] = wildCard(0)
 

--- a/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
@@ -9,7 +9,7 @@ import zio.{ IO, UIO }
  *
  * The concrete subclass [[InetSocketAddress]] is used in practice.
  */
-sealed class SocketAddress private[nio] (private[nio] val jSocketAddress: JSocketAddress) {
+sealed class SocketAddress protected (private[nio] val jSocketAddress: JSocketAddress) {
 
   final override def equals(obj: Any): Boolean =
     obj match {

--- a/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
+++ b/nio-core/src/main/scala/zio/nio/core/InetSocketAddress.scala
@@ -152,6 +152,12 @@ object InetSocketAddress {
   def inetAddressEphemeral(address: InetAddress): UIO[InetSocketAddress] = inetAddress(address, 0)
 
   /**
+   * Creates a socket address for localhost using the specified port.
+   */
+  def localHost(port: Int): IO[UnknownHostException, InetSocketAddress] =
+    InetAddress.localHost.flatMap(inetAddress(_, port))
+
+  /**
    * Creates an unresolved socket address from a hostname and a port number.
    *
    * No attempt will be made to resolve the hostname into an `InetAddress`.

--- a/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/AsynchronousChannel.scala
@@ -65,19 +65,16 @@ abstract class AsynchronousByteChannel private[channels] (protected val channel:
 
 final class AsynchronousServerSocketChannel(protected val channel: JAsynchronousServerSocketChannel) extends Channel {
 
-  /**
-   * Binds the channel's socket to a local address and configures the socket
-   * to listen for connections.
-   */
-  def bind(address: SocketAddress): IO[IOException, Unit] =
-    IO.effect(channel.bind(address.jSocketAddress)).refineToOrDie[IOException].unit
+  def bindTo(local: SocketAddress, backlog: Int = 0): IO[IOException, Unit] = bind(Some(local), backlog)
+
+  def bindAuto(backlog: Int = 0): IO[IOException, Unit] = bind(None, backlog)
 
   /**
    * Binds the channel's socket to a local address and configures the socket
    * to listen for connections, up to backlog pending connection.
    */
-  def bind(address: SocketAddress, backlog: Int): IO[IOException, Unit] =
-    IO.effect(channel.bind(address.jSocketAddress, backlog)).refineToOrDie[IOException].unit
+  def bind(address: Option[SocketAddress], backlog: Int = 0): IO[IOException, Unit] =
+    IO.effect(channel.bind(address.map(_.jSocketAddress).orNull, backlog)).refineToOrDie[IOException].unit
 
   def setOption[T](name: SocketOption[T], value: T): IO[IOException, Unit] =
     IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].unit
@@ -119,13 +116,17 @@ object AsynchronousServerSocketChannel {
       .toNioManaged
 }
 
-class AsynchronousSocketChannel(override protected val channel: JAsynchronousSocketChannel)
+final class AsynchronousSocketChannel(override protected val channel: JAsynchronousSocketChannel)
     extends AsynchronousByteChannel(channel) {
 
-  final def bind(address: SocketAddress): IO[IOException, Unit] =
-    IO.effect(channel.bind(address.jSocketAddress)).refineToOrDie[IOException].unit
+  def bindTo(address: SocketAddress): IO[IOException, Unit] = bind(Some(address))
 
-  final def setOption[T](name: SocketOption[T], value: T): IO[IOException, Unit] =
+  def bindAuto: IO[IOException, Unit] = bind(None)
+
+  def bind(address: Option[SocketAddress]): IO[IOException, Unit] =
+    IO.effect(channel.bind(address.map(_.jSocketAddress).orNull)).refineToOrDie[IOException].unit
+
+  def setOption[T](name: SocketOption[T], value: T): IO[IOException, Unit] =
     IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].unit
 
   final def shutdownInput: IO[IOException, Unit] = IO.effect(channel.shutdownInput()).refineToOrDie[IOException].unit

--- a/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
@@ -15,6 +15,10 @@ final class DatagramChannel private[channels] (override protected[channels] val 
     with SelectableChannel
     with ScatteringByteChannel {
 
+  def bindTo(local: SocketAddress): IO[IOException, Unit] = bind(Some(local))
+
+  def bindAuto: IO[IOException, Unit] = bind(None)
+
   /**
    * Binds this channel's underlying socket to the given local address. Passing `None` binds to an
    * automatically assigned local address.

--- a/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/DatagramChannel.scala
@@ -61,7 +61,7 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the local address if the socket is bound, otherwise `None`
    */
   def localAddress: IO[IOException, Option[SocketAddress]] =
-    IO.effect(channel.getLocalAddress()).refineToOrDie[IOException].map(a => Option(a).map(new SocketAddress(_)))
+    IO.effect(channel.getLocalAddress()).refineToOrDie[IOException].map(a => Option(a).map(SocketAddress.fromJava))
 
   /**
    * Receives a datagram via this channel into the given [[zio.nio.core.ByteBuffer]].
@@ -70,7 +70,9 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the socket address of the datagram's source, if available.
    */
   def receive(dst: ByteBuffer): IO[IOException, Option[SocketAddress]] =
-    IO.effect(channel.receive(dst.byteBuffer)).refineToOrDie[IOException].map(a => Option(a).map(new SocketAddress(_)))
+    IO.effect(channel.receive(dst.byteBuffer))
+      .refineToOrDie[IOException]
+      .map(a => Option(a).map(SocketAddress.fromJava))
 
   /**
    * Optionally returns the remote socket address that this channel's underlying socket is connected to.
@@ -78,7 +80,7 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the remote address if the socket is connected, otherwise `None`
    */
   def remoteAddress: IO[IOException, Option[SocketAddress]] =
-    IO.effect(channel.getRemoteAddress()).refineToOrDie[IOException].map(a => Option(a).map(new SocketAddress(_)))
+    IO.effect(channel.getRemoteAddress()).refineToOrDie[IOException].map(a => Option(a).map(SocketAddress.fromJava))
 
   /**
    * Sends a datagram via this channel to the given target [[zio.nio.core.SocketAddress]].

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
@@ -63,8 +63,12 @@ final class SocketChannel(override protected[channels] val channel: JSocketChann
     with GatheringByteChannel
     with ScatteringByteChannel {
 
-  def bind(local: SocketAddress): IO[IOException, Unit] =
-    IO.effect(channel.bind(local.jSocketAddress)).refineToOrDie[IOException].unit
+  def bindTo(address: SocketAddress): IO[IOException, Unit] = bind(Some(address))
+
+  def bindAuto: IO[IOException, Unit] = bind(None)
+
+  def bind(local: Option[SocketAddress]): IO[IOException, Unit] =
+    IO.effect(channel.bind(local.map(_.jSocketAddress).orNull)).refineToOrDie[IOException].unit
 
   def setOption[T](name: SocketOption[T], value: T): IO[IOException, Unit] =
     IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].unit
@@ -110,12 +114,12 @@ object SocketChannel {
 }
 
 final class ServerSocketChannel(override protected val channel: JServerSocketChannel) extends SelectableChannel {
+  def bindTo(local: SocketAddress, backlog: Int = 0): IO[IOException, Unit] = bind(Some(local), backlog)
 
-  def bind(local: SocketAddress): IO[IOException, Unit] =
-    IO.effect(channel.bind(local.jSocketAddress)).refineToOrDie[IOException].unit
+  def bindAuto(backlog: Int = 0): IO[IOException, Unit] = bind(None, backlog)
 
-  def bind(local: SocketAddress, backlog: Int): IO[IOException, Unit] =
-    IO.effect(channel.bind(local.jSocketAddress, backlog)).refineToOrDie[IOException].unit
+  def bind(local: Option[SocketAddress], backlog: Int = 0): IO[IOException, Unit] =
+    IO.effect(channel.bind(local.map(_.jSocketAddress).orNull, backlog)).refineToOrDie[IOException].unit
 
   def setOption[T](name: SocketOption[T], value: T): IO[IOException, Unit] =
     IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].unit

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectableChannel.scala
@@ -143,7 +143,7 @@ final class ServerSocketChannel(override protected val channel: JServerSocketCha
       })
 
   val localAddress: IO[IOException, SocketAddress] =
-    IO.effect(new SocketAddress(channel.getLocalAddress())).refineToOrDie[IOException]
+    IO.effect(SocketAddress.fromJava(channel.getLocalAddress())).refineToOrDie[IOException]
 }
 
 object ServerSocketChannel {

--- a/nio-core/src/main/scala/zio/nio/core/channels/SelectionKey.scala
+++ b/nio-core/src/main/scala/zio/nio/core/channels/SelectionKey.scala
@@ -56,8 +56,7 @@ final class SelectionKey(private[nio] val selectionKey: jc.SelectionKey) {
    * {{{
    *   for {
    *     _ <- selector.select
-   *     selectedKeys <- selector.selectedKeys
-   *     _ <- IO.foreach_(selectedKeys) { key =>
+   *     _ <- selector.foreachSelectedKey { key =>
    *       key.matchChannel { readyOps => {
    *         case channel: ServerSocketChannel if readyOps(Operation.Accept) =>
    *           // use `channel` to accept connection
@@ -68,7 +67,7 @@ final class SelectionKey(private[nio] val selectionKey: jc.SelectionKey) {
    *             IO.when(readyOps(Operation.Write)) {
    *               // use `channel` to write
    *             }
-   *       } } *> selector.removeKey(key)
+   *       } }
    *     }
    *   } yield ()
    * }}}
@@ -126,6 +125,14 @@ final class SelectionKey(private[nio] val selectionKey: jc.SelectionKey) {
 
   final def attachment: UIO[Option[AnyRef]] = IO.effectTotal(selectionKey.attachment()).map(Option(_))
 
-  override def toString: String = selectionKey.toString()
+  override def toString: String = selectionKey.toString
+
+  override def hashCode(): Int = selectionKey.hashCode()
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case other: SelectionKey => selectionKey.equals(other.selectionKey)
+      case _                   => false
+    }
 
 }

--- a/nio-core/src/test/scala/zio/nio/core/channels/SelectorSpec.scala
+++ b/nio-core/src/test/scala/zio/nio/core/channels/SelectorSpec.scala
@@ -65,13 +65,12 @@ object SelectorSpec extends BaseSpec {
       } yield ()
 
     for {
-      address  <- SocketAddress.inetSocketAddress(0).toManaged_
       scope    <- Managed.scope
       selector <- Selector.open
       channel  <- ServerSocketChannel.open
       _        <- Managed.fromEffect {
                     for {
-                      _      <- channel.bind(address)
+                      _      <- channel.bindAuto()
                       _      <- channel.configureBlocking(false)
                       _      <- channel.register(selector, Operation.Accept)
                       buffer <- Buffer.byte(256)

--- a/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
@@ -67,17 +67,22 @@ class AsynchronousServerSocketChannel(private val channel: JAsynchronousServerSo
 
   /**
    * Binds the channel's socket to a local address and configures the socket
-   * to listen for connections.
+   * to listen for connections, up to backlog pending connection.
    */
-  final def bind(address: SocketAddress): IO[IOException, Unit] =
-    IO.effect(channel.bind(address.jSocketAddress)).refineToOrDie[IOException].unit
+  final def bindTo(local: SocketAddress, backlog: Int = 0): IO[IOException, Unit] = bind(Some(local), backlog)
+
+  /**
+   * Binds the channel's socket to an automatically assigned local address and configures the socket
+   * to listen for connections, up to backlog pending connection.
+   */
+  final def bindAuto(backlog: Int = 0): IO[IOException, Unit] = bind(None, backlog)
 
   /**
    * Binds the channel's socket to a local address and configures the socket
    * to listen for connections, up to backlog pending connection.
    */
-  final def bind(address: SocketAddress, backlog: Int): IO[IOException, Unit] =
-    IO.effect(channel.bind(address.jSocketAddress, backlog)).refineToOrDie[IOException].unit
+  final def bind(address: Option[SocketAddress], backlog: Int = 0): IO[IOException, Unit] =
+    IO.effect(channel.bind(address.map(_.jSocketAddress).orNull, backlog)).refineToOrDie[IOException].unit
 
   final def setOption[T](name: SocketOption[T], value: T): IO[IOException, Unit] =
     IO.effect(channel.setOption(name, value)).refineToOrDie[IOException].unit

--- a/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/AsynchronousChannel.scala
@@ -106,7 +106,7 @@ class AsynchronousServerSocketChannel(private val channel: JAsynchronousServerSo
    */
   final def localAddress: IO[IOException, Option[SocketAddress]] =
     IO.effect(
-      Option(channel.getLocalAddress).map(new SocketAddress(_))
+      Option(channel.getLocalAddress).map(SocketAddress.fromJava)
     ).refineToOrDie[IOException]
 
   /**

--- a/nio/src/main/scala/zio/nio/channels/DatagramChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/DatagramChannel.scala
@@ -43,7 +43,7 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the local address if the socket is bound, otherwise `None`
    */
   def localAddress: IO[IOException, Option[SocketAddress]] =
-    IO.effect(channel.getLocalAddress()).refineToOrDie[IOException].map(a => Option(a).map(new SocketAddress(_)))
+    IO.effect(Option(channel.getLocalAddress()).map(SocketAddress.fromJava)).refineToOrDie[IOException]
 
   /**
    * Receives a datagram via this channel into the given [[zio.nio.core.ByteBuffer]].
@@ -52,7 +52,9 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the socket address of the datagram's source, if available.
    */
   def receive(dst: ByteBuffer): IO[IOException, Option[SocketAddress]] =
-    IO.effect(channel.receive(dst.byteBuffer)).refineToOrDie[IOException].map(a => Option(a).map(new SocketAddress(_)))
+    IO.effect(channel.receive(dst.byteBuffer))
+      .refineToOrDie[IOException]
+      .map(a => Option(a).map(SocketAddress.fromJava))
 
   /**
    * Optionally returns the remote socket address that this channel's underlying socket is connected to.
@@ -60,7 +62,7 @@ final class DatagramChannel private[channels] (override protected[channels] val 
    * @return the remote address if the socket is connected, otherwise `None`
    */
   def remoteAddress: IO[IOException, Option[SocketAddress]] =
-    IO.effect(channel.getRemoteAddress()).refineToOrDie[IOException].map(a => Option(a).map(new SocketAddress(_)))
+    IO.effect(Option(channel.getRemoteAddress()).map(SocketAddress.fromJava)).refineToOrDie[IOException]
 
   /**
    * Sends a datagram via this channel to the given target [[zio.nio.core.SocketAddress]].

--- a/nio/src/main/scala/zio/nio/channels/DatagramChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/DatagramChannel.scala
@@ -110,6 +110,21 @@ object DatagramChannel {
   def bind(local: Option[SocketAddress]): Managed[IOException, DatagramChannel] = open.flatMap(_.bind(local).toManaged_)
 
   /**
+   * Opens a datagram channel bound to the given local address as a managed resource.
+   *
+   * @param local the local address
+   * @return a datagram channel bound to the local address
+   */
+  def bindTo(local: SocketAddress): Managed[IOException, DatagramChannel] = open.flatMap(_.bind(Some(local)).toManaged_)
+
+  /**
+   * Opens a datagram channel bound to an automatically assigned local address as a managed resource.
+   *
+   * @return a datagram channel bound to the local address
+   */
+  def bindAuto: Managed[IOException, DatagramChannel] = open.flatMap(_.bind(None).toManaged_)
+
+  /**
    * Opens a datagram channel connected to the given remote address as a managed resource.
    *
    * @param remote the remote address

--- a/nio/src/main/scala/zio/nio/channels/SelectableChannel.scala
+++ b/nio/src/main/scala/zio/nio/channels/SelectableChannel.scala
@@ -147,7 +147,7 @@ final class ServerSocketChannel private (override protected val channel: JServer
     IO.effect(Option(channel.accept()).map(new SocketChannel(_))).refineToOrDie[IOException]
 
   final val localAddress: IO[IOException, SocketAddress] =
-    IO.effect(new SocketAddress(channel.getLocalAddress())).refineToOrDie[IOException]
+    IO.effect(SocketAddress.fromJava(channel.getLocalAddress())).refineToOrDie[IOException]
 }
 
 object ServerSocketChannel {

--- a/nio/src/test/scala/zio/nio/channels/DatagramChannelSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/DatagramChannelSpec.scala
@@ -1,7 +1,7 @@
 package zio.nio.channels
 
 import zio.nio._
-import zio.nio.core.{ Buffer, SocketAddress }
+import zio.nio.core.{ Buffer, InetSocketAddress, SocketAddress }
 import zio.test.Assertion._
 import zio.test._
 import zio._
@@ -13,7 +13,7 @@ object DatagramChannelSpec extends BaseSpec {
       testM("read/write") {
         def echoServer(started: Promise[Nothing, SocketAddress]): IO[Exception, Unit] =
           for {
-            address <- SocketAddress.inetSocketAddress(0)
+            address <- InetSocketAddress.wildCard(0)
             sink    <- Buffer.byte(3)
             _       <- DatagramChannel
                          .bind(Some(address))
@@ -72,7 +72,7 @@ object DatagramChannelSpec extends BaseSpec {
           } yield worker
 
         for {
-          address       <- SocketAddress.inetSocketAddress(0)
+          address       <- InetSocketAddress.wildCard(0)
           serverStarted <- Promise.make[Nothing, SocketAddress]
           s1            <- server(address, serverStarted)
           addr          <- serverStarted.await

--- a/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
@@ -38,32 +38,31 @@ object SelectorSpec extends BaseSpec {
       buffer: ByteBuffer
     ): ZIO[Blocking, Exception, Unit] =
       for {
-        _            <- selector.select
-        selectedKeys <- selector.selectedKeys
-        _            <- IO.foreach(selectedKeys) { key =>
-                          IO.whenM(safeStatusCheck(key.isAcceptable)) {
-                            for {
-                              clientOpt <- channel.accept
-                              client     = clientOpt.get
-                              _         <- client.configureBlocking(false)
-                              _         <- client.register(selector, Operation.Read)
-                            } yield ()
-                          } *>
-                            IO.whenM(safeStatusCheck(key.isReadable)) {
-                              IO.effectSuspendTotal {
-                                val sClient = key.channel
-                                val client  = sClient.asInstanceOf[zio.nio.core.channels.SocketChannel]
-                                for {
-                                  _ <- client.read(buffer)
-                                  _ <- buffer.flip
-                                  _ <- client.write(buffer)
-                                  _ <- buffer.clear
-                                  _ <- client.close
-                                } yield ()
-                              }
-                            } *>
-                            selector.removeKey(key)
-                        }
+        _ <- selector.select
+        _ <- selector.foreachSelectedKey { key =>
+               IO.whenM(safeStatusCheck(key.isAcceptable)) {
+                 for {
+                   clientOpt <- channel.accept
+                   client     = clientOpt.get
+                   _         <- client.configureBlocking(false)
+                   _         <- client.register(selector, Operation.Read)
+                 } yield ()
+               } *>
+                 IO.whenM(safeStatusCheck(key.isReadable)) {
+                   IO.effectSuspendTotal {
+                     val sClient = key.channel
+                     val client  = sClient.asInstanceOf[zio.nio.core.channels.SocketChannel]
+                     for {
+                       _ <- client.read(buffer)
+                       _ <- buffer.flip
+                       _ <- client.write(buffer)
+                       _ <- buffer.clear
+                       _ <- client.close
+                     } yield ()
+                   }
+                 }.as(true)
+             }
+        _ <- selector.selectedKeys.filterOrDieMessage(_.isEmpty)("Selected key set should be empty")
       } yield ()
 
     for {

--- a/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
+++ b/nio/src/test/scala/zio/nio/channels/SelectorSpec.scala
@@ -1,11 +1,10 @@
 package zio.nio.channels
 
 import java.nio.channels.CancelledKeyException
-
 import zio._
 import zio.blocking.Blocking
 import zio.clock.Clock
-import zio.nio.core.{ Buffer, ByteBuffer, SocketAddress }
+import zio.nio.core.{ Buffer, ByteBuffer, InetSocketAddress, SocketAddress }
 import zio.nio.core.channels.SelectionKey.Operation
 import zio.nio.BaseSpec
 import zio.test._
@@ -68,11 +67,11 @@ object SelectorSpec extends BaseSpec {
       } yield ()
 
     for {
-      address <- SocketAddress.inetSocketAddress(0)
+      address <- InetSocketAddress.wildCard(0)
       _       <- Selector.make.use { selector =>
                    ServerSocketChannel.open.use { channel =>
                      for {
-                       _      <- channel.bind(address)
+                       _      <- channel.bindTo(address)
                        _      <- channel.configureBlocking(false)
                        _      <- channel.register(selector, Operation.Accept)
                        buffer <- Buffer.byte(256)


### PR DESCRIPTION
This is a cherry-pick of several commits from the `quelgar/next-gen` branch, ported back to zio-nio and zio-nio-core modules.

* Improve InetSocketAddress and socket binding APIs.
* Use meaningful names for the InetSocketAddress constructors.
* Make binding to an automatically assigned socket address explicit.
* Improvements to address handling.
* Improve InetSocketAddress API.
* Add localhost constructor to InetSocketAddress.