### PR TITLE
delete recursive

### DIFF
--- a/nio/src/main/scala/zio/nio/file/Files.scala
+++ b/nio/src/main/scala/zio/nio/file/Files.scala
@@ -19,7 +19,7 @@ import java.nio.file.{
   Path => JPath
 }
 import java.util.function.BiPredicate
-import java.util.{ Iterator => JIterator }
+import java.util.{ Comparator, Iterator => JIterator }
 import scala.jdk.CollectionConverters._
 import scala.reflect._
 
@@ -133,8 +133,15 @@ object Files {
   def deleteIfExists(path: Path): ZIO[Blocking, IOException, Boolean] =
     effectBlocking(JFiles.deleteIfExists(path.javaPath)).refineToOrDie[IOException]
 
-  def deleteRecursive(path: Path): ZIO[Blocking, IOException, Long] =
-    newDirectoryStream(path).mapM(delete).run(ZSink.count) <* delete(path)
+  def deleteRecursive(path: Path): ZIO[Blocking, IOException, Long] = {
+    val managed = ZManaged.fromAutoCloseable(
+      effectBlocking(JFiles.walk(path.javaPath).sorted(Comparator.reverseOrder[java.nio.file.Path]()))
+        .refineToOrDie[IOException]
+    )
+    val stream  =
+      ZStream.managed(managed).mapM(dirStream => UIO(dirStream.iterator())).flatMap(fromJavaIterator).map(Path.fromJava)
+    stream.mapM(delete).run(ZSink.count)
+  }
 
   def copy(source: Path, target: Path, copyOptions: CopyOption*): ZIO[Blocking, IOException, Unit] =
     effectBlocking(JFiles.copy(source.javaPath, target.javaPath, copyOptions: _*)).unit

--- a/nio/src/test/scala/zio/nio/file/FilesSpec.scala
+++ b/nio/src/test/scala/zio/nio/file/FilesSpec.scala
@@ -84,6 +84,17 @@ object FilesSpec extends BaseSpec {
           tmpFileExistsAfterUsage <- Files.exists(tmpFilePath)
         } yield assert(readBytes)(equalTo(sampleFileContent)) &&
           assert(tmpFileExistsAfterUsage)(isFalse)
+      },
+      testM("deleteRecursive (dir) deletes directory with subdirectories") {
+        for {
+          dir         <- Files.createTempDirectory(Path("."), None, Nil)
+          subDir       = dir / Path("subDir")
+          _           <- Files.createDirectory(subDir)
+          _           <- Files.createFile(subDir / Path("subFile"))
+          existingDir <- Files.exists(dir)
+          _           <- Files.deleteRecursive(dir)
+          deletedDir  <- Files.exists(dir)
+        } yield assert(existingDir)(isTrue) && assert(deletedDir)(isFalse)
       }
     )
 


### PR DESCRIPTION
Original `deleteRecursive` was able to delete directory with files. This version can delete full directory tree (inner dirs with files).