### PR TITLE
remove cross version for collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val zioNioCore = project
     libraryDependencies ++= Seq(
       "dev.zio"                 %% "zio"                     % zioVersion,
       "dev.zio"                 %% "zio-streams"             % zioVersion,
-      ("org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0").cross(CrossVersion.for3Use2_13),
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
       "dev.zio"                 %% "zio-test"                % zioVersion % Test,
       "dev.zio"                 %% "zio-test-sbt"            % zioVersion % Test
     ),


### PR DESCRIPTION
When trying to add Scala3 to zio-zmx this cross version modifier was causing problems since zio-nio brings 2_13 version of scala-collection-compat while zio-json brings scala-collection-compat_3.