### PR TITLE
Build cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.11.12', '2.12.14', '2.13.6', '3.0.0']
+        scala: ['2.11.12', '2.12.14', '2.13.6', '3.0.1']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,12 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Run tests
-        run: sbt ++${{ matrix.scala }}! test
+      - name: Test 2.x
+        if: ${{ !startsWith(matrix.scala, '3.0.') }}
+        run: ./sbt ++${{ matrix.scala }}! test
+      - name: Test 3.x
+        if: ${{ startsWith(matrix.scala, '3.0.') }}
+        run: ./sbt ++${{ matrix.scala }}! testDotty
 
   ci:
     runs-on: ubuntu-20.04

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,10 @@ inThisBuild(
 addCommandAlias("fix", "; all compile:scalafix test:scalafix; all scalafmtSbt scalafmtAll")
 addCommandAlias("check", "; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
 addCommandAlias("coverageReport", "clean coverage test coverageReport coverageAggregate")
+addCommandAlias(
+  "testDotty",
+  ";zioNioCore/test;zioNio/test;examples/test"
+)
 
 val zioVersion = "1.0.11"
 
@@ -22,11 +26,11 @@ lazy val zioNioCore = project
   .settings(stdSettings("zio-nio-core"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"                 %% "zio"                     % zioVersion,
-      "dev.zio"                 %% "zio-streams"             % zioVersion,
+      "dev.zio"                %% "zio"                     % zioVersion,
+      "dev.zio"                %% "zio-streams"             % zioVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
-      "dev.zio"                 %% "zio-test"                % zioVersion % Test,
-      "dev.zio"                 %% "zio-test-sbt"            % zioVersion % Test
+      "dev.zio"                %% "zio-test"                % zioVersion % Test,
+      "dev.zio"                %% "zio-test-sbt"            % zioVersion % Test
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossprojec
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.1.0")
 addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.7.0")
 addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.4.0")
-addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.2.22")
+addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.2.23")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.3")
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"                 % "1.8.2")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")


### PR DESCRIPTION
- update Scala to 3.0.1
- update mdoc to 2.2.23
- remove build configuration for macros
- remove build configuration for cross-platform builds
- exclude `docs` from Scala 3 build (as it causes cross-version errors)