### PR TITLE
Fix UnsupportedOperationException

### DIFF
--- a/nio/src/main/scala/zio/nio/file/Files.scala
+++ b/nio/src/main/scala/zio/nio/file/Files.scala
@@ -218,7 +218,7 @@ object Files {
 
   }
 
-  final case class Attributes(attributeNames: AttributeNames, viewName: String = "base") {
+  final case class Attributes(attributeNames: AttributeNames, viewName: String = "basic") {
     def toJava: String = s"$viewName:${attributeNames.toJava}"
   }
 

--- a/nio/src/test/scala/zio/nio/file/FilesSpec.scala
+++ b/nio/src/test/scala/zio/nio/file/FilesSpec.scala
@@ -3,11 +3,14 @@ package zio.nio.file
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.nio.BaseSpec
+import zio.nio.file.Files.Attributes
 import zio.random.Random
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment._
-import zio.{Chunk, Has, Ref}
+import zio.{Chunk, Has, Ref, ZIO}
+
+import java.io.IOException
 
 object FilesSpec extends BaseSpec {
 
@@ -83,6 +86,16 @@ object FilesSpec extends BaseSpec {
           tmpFileExistsAfterUsage <- Files.exists(tmpFilePath)
         } yield assert(readBytes)(equalTo(sampleFileContent)) &&
           assert(tmpFileExistsAfterUsage)(isFalse)
+      },
+      testM("readAttributes works") {
+        for {
+          file       <- ZIO.succeed(Path("nio/src/test/resources/async_file_read_test.txt"))
+          attributes <- ZIO.succeed(Attributes.fromJava("size")).someOrFail(new IOException("fromJava issue"))
+          attrs      <- Files.readAttributes(file, attributes)
+          size        = Long unbox attrs("size")
+        } yield {
+          assert(size)(equalTo(11L))
+        }
       }
     )
 

--- a/nio/src/test/scala/zio/nio/file/WatchServiceSpec.scala
+++ b/nio/src/test/scala/zio/nio/file/WatchServiceSpec.scala
@@ -8,7 +8,7 @@ import zio.test._
 import java.io.IOException
 import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
 
-object WathServiceSpec extends BaseSpec {
+object WatchServiceSpec extends BaseSpec {
 
   override def spec: Spec[Blocking, TestFailure[IOException], TestSuccess] =
     suite("WatchServiceSpec")(


### PR DESCRIPTION
According to the JDK javadocs, the default view name is `basic`. Sending in `base` results in `java.lang.UnsupportedOperationException: View 'base' not available`

Also renamed a typo'd test class